### PR TITLE
Modify student history query so it matches more closely the desired tutor-behavior

### DIFF
--- a/app/domain/services/prepare_clue_calculations/service.rb
+++ b/app/domain/services/prepare_clue_calculations/service.rb
@@ -139,7 +139,7 @@ class Services::PrepareClueCalculations::Service < Services::ApplicationService
         Response
           .joins(:exercise, assigned_exercise: :assignment)
           .where(response_query)
-          .order(:responded_at)
+          .order(:last_responded_at)
           .pluck(:uuid, :trial_uuid, :student_uuid, :group_uuid, :is_correct, :feedback_at)
           .each do |response_uuid, trial_uuid, student_uuid, group_uuid, is_correct, feedback_at|
           used_response_uuids << response_uuid

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -63,29 +63,46 @@ class Assignment < ApplicationRecord
     end
     current_time ||= Time.current
 
+    # We use DENSE_RANK() for the student history because we want all assignments
+    # not yet in the student history to receive SPEs as if they were next in line
+    # One of the conditions for adding an assignment to the student history is answering questions
+    # and we do recalculate all outstanding SPEs for that student after every question answered
+    # Unfortunately, we don't yet recalculate all SPEs for a student after an incomplete assignment
+    # becomes due (the other condition for adding assignments to the student history)
+    # Avoiding stale SPEs when incomplete assignments become due would probably require
+    # a background job checking that condition periodically
     from(
       <<-SQL.strip_heredoc
         (
-          SELECT assignments.*, assignment_core_steps_completion.student_history_at,
-            row_number() OVER (
+          SELECT assignments.*,
+            assignment_core_step_responses.student_history_at,
+            ROW_NUMBER() OVER (
               PARTITION BY assignments.student_uuid, assignments.assignment_type
               ORDER BY assignments.due_at ASC, assignments.opens_at ASC, assignments.created_at ASC
             ) AS instructor_driven_sequence_number,
-            row_number() OVER (
+            DENSE_RANK() OVER (
               PARTITION BY assignments.student_uuid, assignments.assignment_type
-              ORDER BY assignment_core_steps_completion.student_history_at ASC
+              ORDER BY assignment_core_step_responses.student_history_at ASC
             ) AS student_driven_sequence_number
           FROM assignments
             LEFT OUTER JOIN LATERAL (
-              SELECT COALESCE(MAX(responses.responded_at), assignments.due_at) AS student_history_at
+              SELECT CASE
+                WHEN EVERY(responses.id IS NOT NULL)
+                  THEN MAX(responses.first_responded_at)
+                WHEN assignments.due_at <= '#{current_time.to_s(:db)}'
+                  THEN assignments.due_at
+                END AS student_history_at
               FROM assigned_exercises
-              LEFT OUTER JOIN responses ON responses.trial_uuid = assigned_exercises.uuid
+              LEFT OUTER JOIN responses
+                ON responses.trial_uuid = assigned_exercises.uuid
+                  AND (
+                    assignments.due_at IS NULL
+                      OR responses.first_responded_at <= assignments.due_at
+                  )
               WHERE assigned_exercises.assignment_uuid = assignments.uuid
                 AND assigned_exercises.is_spe = FALSE
               GROUP BY assigned_exercises.assignment_uuid
-              HAVING COUNT(assigned_exercises.*) = COUNT(DISTINCT responses.trial_uuid)
-                OR assignments.due_at <= '#{current_time.to_s(:db)}'
-            ) AS assignment_core_steps_completion
+            ) AS assignment_core_step_responses
               ON TRUE
           #{"WHERE #{wheres.join(' AND ')}" unless wheres.empty?}
         ) AS assignments

--- a/app/models/response.rb
+++ b/app/models/response.rb
@@ -13,5 +13,6 @@ class Response < ApplicationRecord
   validates :trial_uuid,     presence: true
   validates :student_uuid,   presence: true
   validates :exercise_uuid,  presence: true
-  validates :responded_at,   presence: true
+  validates :first_responded_at,   presence: true
+  validates :last_responded_at,   presence: true
 end

--- a/db/migrate/20170215215802_create_responses.rb
+++ b/db/migrate/20170215215802_create_responses.rb
@@ -6,7 +6,8 @@ class CreateResponses < ActiveRecord::Migration[5.0]
       t.uuid     :trial_uuid,                       null: false, index: true
       t.uuid     :student_uuid,                     null: false, index: true
       t.uuid     :exercise_uuid,                    null: false
-      t.datetime :responded_at,                     null: false, index: true
+      t.datetime :first_responded_at,               null: false, index: true
+      t.datetime :last_responded_at,                null: false, index: true
       t.boolean  :is_correct,                       null: false
       t.boolean  :used_in_clue_calculations,        null: false, index: true
       t.boolean  :used_in_exercise_calculations,    null: false, index: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -258,7 +258,8 @@ ActiveRecord::Schema.define(version: 20170404212728) do
     t.uuid     "trial_uuid",                       null: false
     t.uuid     "student_uuid",                     null: false
     t.uuid     "exercise_uuid",                    null: false
-    t.datetime "responded_at",                     null: false
+    t.datetime "first_responded_at",               null: false
+    t.datetime "last_responded_at",                null: false
     t.boolean  "is_correct",                       null: false
     t.boolean  "used_in_clue_calculations",        null: false
     t.boolean  "used_in_exercise_calculations",    null: false
@@ -267,7 +268,8 @@ ActiveRecord::Schema.define(version: 20170404212728) do
     t.datetime "updated_at",                       null: false
     t.index ["ecosystem_uuid"], name: "index_responses_on_ecosystem_uuid", using: :btree
     t.index ["exercise_uuid", "used_in_ecosystem_matrix_updates"], name: "index_responses_on_ex_uuid_and_used_in_eco_mtx_updates", using: :btree
-    t.index ["responded_at"], name: "index_responses_on_responded_at", using: :btree
+    t.index ["first_responded_at"], name: "index_responses_on_first_responded_at", using: :btree
+    t.index ["last_responded_at"], name: "index_responses_on_last_responded_at", using: :btree
     t.index ["student_uuid"], name: "index_responses_on_student_uuid", using: :btree
     t.index ["trial_uuid"], name: "index_responses_on_trial_uuid", using: :btree
     t.index ["used_in_clue_calculations"], name: "index_responses_on_used_in_clue_calculations", using: :btree

--- a/spec/factories/responses.rb
+++ b/spec/factories/responses.rb
@@ -1,14 +1,16 @@
 FactoryGirl.define do
   factory :response do
-    uuid                             { SecureRandom.uuid }
-    ecosystem_uuid                   { SecureRandom.uuid }
-    trial_uuid                       { SecureRandom.uuid }
-    student_uuid                     { SecureRandom.uuid }
-    exercise_uuid                    { SecureRandom.uuid }
-    responded_at                     { Time.now }
-    is_correct                       { [true, false].sample }
-    used_in_clue_calculations        { [true, false].sample }
-    used_in_exercise_calculations    { [true, false].sample }
-    used_in_ecosystem_matrix_updates { [true, false].sample }
+    transient                        { current_time { Time.current } }
+    uuid                             { SecureRandom.uuid             }
+    ecosystem_uuid                   { SecureRandom.uuid             }
+    trial_uuid                       { SecureRandom.uuid             }
+    student_uuid                     { SecureRandom.uuid             }
+    exercise_uuid                    { SecureRandom.uuid             }
+    first_responded_at               { current_time                  }
+    last_responded_at                { current_time                  }
+    is_correct                       { [true, false].sample          }
+    used_in_clue_calculations        { [true, false].sample          }
+    used_in_exercise_calculations    { [true, false].sample          }
+    used_in_ecosystem_matrix_updates { [true, false].sample          }
   end
 end

--- a/spec/models/response_spec.rb
+++ b/spec/models/response_spec.rb
@@ -5,9 +5,10 @@ RSpec.describe Response, type: :model do
 
   it { is_expected.to belong_to :exercise }
 
-  it { is_expected.to validate_presence_of :ecosystem_uuid }
-  it { is_expected.to validate_presence_of :trial_uuid     }
-  it { is_expected.to validate_presence_of :student_uuid   }
-  it { is_expected.to validate_presence_of :exercise_uuid  }
-  it { is_expected.to validate_presence_of :responded_at   }
+  it { is_expected.to validate_presence_of :ecosystem_uuid     }
+  it { is_expected.to validate_presence_of :trial_uuid         }
+  it { is_expected.to validate_presence_of :student_uuid       }
+  it { is_expected.to validate_presence_of :exercise_uuid      }
+  it { is_expected.to validate_presence_of :first_responded_at }
+  it { is_expected.to validate_presence_of :last_responded_at  }
 end


### PR DESCRIPTION
I asked kef parts of this question already, but the answer led to more questions:

- If a student works all core steps in an assignment and it enters their history, can the history position of the assignment change if the student returns later and changes some answers?

- If the student partially works an assignment and then that assignment becomes due, is the assignment's position in the history determined by the date of the last worked exercise or the due date?

- Can the position of the past-due assignment change if the student works more questions after the due date?

kef [4:38 PM] 
For simplicity, I think the assignment position should stay put in all those cases. 
1. Stays put even if they change answers.
2. Should be due date, since it was partial.
3. After the due date, the assignment doesn’t move.