### PR TITLE
Reduce database IO for ecosystem matrix updates

### DIFF
--- a/app/domain/services/fetch_ecosystem_events/service.rb
+++ b/app/domain/services/fetch_ecosystem_events/service.rb
@@ -148,7 +148,8 @@ class Services::FetchEcosystemEvents::Service < Services::ApplicationService
           exercise_groups << ExerciseGroup.new(
             uuid: group_uuid,
             response_count: 0,
-            used_in_ecosystem_matrix_updates: false
+            next_update_response_count: 1,
+            trigger_ecosystem_matrix_update: true
           )
         end
 
@@ -165,8 +166,7 @@ class Services::FetchEcosystemEvents::Service < Services::ApplicationService
               uuid: SecureRandom.uuid,
               ecosystem_uuid: ecosystem_uuid,
               exercise_uuid: exercise_uuid,
-              book_container_uuids: book_container_uuids,
-              next_ecosystem_matrix_update_response_count: 0
+              book_container_uuids: book_container_uuids
             )
           end
         end
@@ -178,7 +178,9 @@ class Services::FetchEcosystemEvents::Service < Services::ApplicationService
     end.compact
 
     results << ExerciseGroup.import(
-      exercise_groups, validate: false, on_duplicate_key_ignore: { conflict_target: [ :uuid ] }
+      exercise_groups, validate: false, on_duplicate_key_update: {
+        conflict_target: [ :uuid ], columns: [ :trigger_ecosystem_matrix_update ]
+      }
     )
 
     results << Exercise.import(

--- a/app/models/ecosystem_exercise.rb
+++ b/app/models/ecosystem_exercise.rb
@@ -35,9 +35,6 @@ class EcosystemExercise < ApplicationRecord
 
   validates :book_container_uuids, presence: true
 
-  validates :next_ecosystem_matrix_update_response_count, presence: true,
-                                                          numericality: { only_integer: true }
-
   scope :with_group_uuids, -> do
     joins(:exercise).select [arel_table[Arel.star], Exercise.arel_table[:group_uuid]]
   end

--- a/app/models/exercise_group.rb
+++ b/app/models/exercise_group.rb
@@ -4,5 +4,6 @@ class ExerciseGroup < ApplicationRecord
                        dependent: :destroy,
                        inverse_of: :exercise_group
 
-  validates :response_count, presence: true, numericality: { only_integer: true }
+  validates :response_count, :next_update_response_count,
+            presence: true, numericality: { only_integer: true }
 end

--- a/db/migrate/20180320200143_redo_ecosystem_exercises_and_exercise_groups.rb
+++ b/db/migrate/20180320200143_redo_ecosystem_exercises_and_exercise_groups.rb
@@ -1,0 +1,30 @@
+class RedoEcosystemExercisesAndExerciseGroups < ActiveRecord::Migration[5.0]
+  def up
+    add_column :exercise_groups, :next_update_response_count, :integer
+
+    change_column_null :exercise_groups, :next_update_response_count, false, 0
+
+    rename_column :exercise_groups, :used_in_ecosystem_matrix_updates,
+                                    :trigger_ecosystem_matrix_update
+
+    ExerciseGroup.update_all(trigger_ecosystem_matrix_update: true)
+
+    remove_column :ecosystem_exercises, :next_ecosystem_matrix_update_response_count
+  end
+
+  def down
+    add_column :ecosystem_exercises, :next_ecosystem_matrix_update_response_count, :integer
+
+    change_column_null :ecosystem_exercises, :next_ecosystem_matrix_update_response_count, false, 0
+
+    add_index :ecosystem_exercises, :next_ecosystem_matrix_update_response_count,
+              name: 'index_ecosystem_exercises_on_next_eco_mtx_upd_response_count'
+
+    rename_column :exercise_groups, :trigger_ecosystem_matrix_update,
+                                    :used_in_ecosystem_matrix_updates
+
+    rename_column :exercise_groups, :next_update_response_count, :response_count
+
+    ExerciseGroup.update_all(used_in_ecosystem_matrix_updates: false, response_count: 0)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180319193544) do
+ActiveRecord::Schema.define(version: 20180320200143) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -183,16 +183,14 @@ ActiveRecord::Schema.define(version: 20180319193544) do
   end
 
   create_table "ecosystem_exercises", force: :cascade do |t|
-    t.uuid     "uuid",                                        null: false
-    t.uuid     "ecosystem_uuid",                              null: false
-    t.uuid     "exercise_uuid",                               null: false
-    t.uuid     "book_container_uuids",                        null: false, array: true
-    t.datetime "created_at",                                  null: false
-    t.datetime "updated_at",                                  null: false
-    t.integer  "next_ecosystem_matrix_update_response_count", null: false
+    t.uuid     "uuid",                 null: false
+    t.uuid     "ecosystem_uuid",       null: false
+    t.uuid     "exercise_uuid",        null: false
+    t.uuid     "book_container_uuids", null: false, array: true
+    t.datetime "created_at",           null: false
+    t.datetime "updated_at",           null: false
     t.index ["ecosystem_uuid"], name: "index_ecosystem_exercises_on_ecosystem_uuid", using: :btree
     t.index ["exercise_uuid", "ecosystem_uuid"], name: "index_eco_exercises_on_exercise_uuid_and_eco_uuid", unique: true, using: :btree
-    t.index ["next_ecosystem_matrix_update_response_count"], name: "index_ecosystem_exercises_on_next_eco_mtx_upd_response_count", using: :btree
     t.index ["uuid"], name: "index_ecosystem_exercises_on_uuid", unique: true, using: :btree
   end
 
@@ -241,12 +239,13 @@ ActiveRecord::Schema.define(version: 20180319193544) do
   end
 
   create_table "exercise_groups", force: :cascade do |t|
-    t.uuid     "uuid",                             null: false
-    t.integer  "response_count",                   null: false
-    t.datetime "created_at",                       null: false
-    t.datetime "updated_at",                       null: false
-    t.boolean  "used_in_ecosystem_matrix_updates", null: false
-    t.index ["used_in_ecosystem_matrix_updates"], name: "index_exercise_groups_on_used_in_ecosystem_matrix_updates", using: :btree
+    t.uuid     "uuid",                            null: false
+    t.integer  "response_count",                  null: false
+    t.datetime "created_at",                      null: false
+    t.datetime "updated_at",                      null: false
+    t.boolean  "trigger_ecosystem_matrix_update", null: false
+    t.integer  "next_update_response_count",      null: false
+    t.index ["trigger_ecosystem_matrix_update"], name: "index_exercise_groups_on_trigger_ecosystem_matrix_update", using: :btree
     t.index ["uuid"], name: "index_exercise_groups_on_uuid", unique: true, using: :btree
   end
 

--- a/spec/domain/services/prepare_ecosystem_matrix_updates/service_spec.rb
+++ b/spec/domain/services/prepare_ecosystem_matrix_updates/service_spec.rb
@@ -20,20 +20,32 @@ RSpec.describe Services::PrepareEcosystemMatrixUpdates::Service, type: :service 
       @ecosystem_3 = FactoryGirl.create :ecosystem
       @ecosystem_4 = FactoryGirl.create :ecosystem
 
+      exercise_group_1 = FactoryGirl.create :exercise_group, next_update_response_count: 1,
+                                                             trigger_ecosystem_matrix_update: false
+      exercise_1 = FactoryGirl.create :exercise, exercise_group: exercise_group_1
       @ecosystem_exercise_1 = FactoryGirl.create :ecosystem_exercise,
-                                                 ecosystem_uuid: @ecosystem_1.uuid,
-                                                 next_ecosystem_matrix_update_response_count: 1
+                                                 ecosystem: @ecosystem_1,
+                                                 exercise: exercise_1
+
+      exercise_group_2 = FactoryGirl.create :exercise_group, next_update_response_count: 2,
+                                                             trigger_ecosystem_matrix_update: false
+      exercise_2 = FactoryGirl.create :exercise, exercise_group: exercise_group_2
       @ecosystem_exercise_2 = FactoryGirl.create :ecosystem_exercise,
-                                                 ecosystem_uuid: @ecosystem_2.uuid,
-                                                 next_ecosystem_matrix_update_response_count: 2
+                                                 ecosystem: @ecosystem_2,
+                                                 exercise: exercise_2
+
+      exercise_group_3 = FactoryGirl.create :exercise_group, next_update_response_count: 1,
+                                                             trigger_ecosystem_matrix_update: false
+      exercise_3 = FactoryGirl.create :exercise, exercise_group: exercise_group_3
       @ecosystem_exercise_3 = FactoryGirl.create :ecosystem_exercise,
-                                                 ecosystem_uuid: @ecosystem_3.uuid,
-                                                 next_ecosystem_matrix_update_response_count: 1
-      exercise_group = FactoryGirl.create :exercise_group, used_in_ecosystem_matrix_updates: false
-      exercise = FactoryGirl.create :exercise, exercise_group: exercise_group
+                                                 ecosystem: @ecosystem_3,
+                                                 exercise: exercise_3
+
+      exercise_group_4 = FactoryGirl.create :exercise_group, trigger_ecosystem_matrix_update: true
+      exercise_4 = FactoryGirl.create :exercise, exercise_group: exercise_group_4
       @ecosystem_exercise_4 = FactoryGirl.create :ecosystem_exercise,
-                                                 ecosystem_uuid: @ecosystem_4.uuid,
-                                                 exercise: exercise
+                                                 ecosystem: @ecosystem_4,
+                                                 exercise: exercise_4
 
       @response_1 = FactoryGirl.create :response,
                                        ecosystem_uuid: @ecosystem_exercise_1.ecosystem_uuid,

--- a/spec/factories/ecosystem_exercises.rb
+++ b/spec/factories/ecosystem_exercises.rb
@@ -6,6 +6,5 @@ FactoryGirl.define do
     ecosystem
     exercise
     book_container_uuids { book_containers_count.times.map { SecureRandom.uuid } }
-    next_ecosystem_matrix_update_response_count 0
   end
 end

--- a/spec/factories/exercise_groups.rb
+++ b/spec/factories/exercise_groups.rb
@@ -1,7 +1,8 @@
 FactoryGirl.define do
   factory :exercise_group do
-    uuid                             { SecureRandom.uuid }
-    response_count                   0
-    used_in_ecosystem_matrix_updates { [true, false].sample }
+    uuid                            { SecureRandom.uuid }
+    response_count                  0
+    next_update_response_count      1
+    trigger_ecosystem_matrix_update { [ true, false ].sample }
   end
 end

--- a/spec/models/ecosystem_exercise_spec.rb
+++ b/spec/models/ecosystem_exercise_spec.rb
@@ -11,11 +11,4 @@ RSpec.describe EcosystemExercise, type: :model do
   it { is_expected.to have_many(:teacher_clue_calculations) }
 
   it { is_expected.to validate_presence_of :book_container_uuids }
-  it { is_expected.to validate_presence_of :next_ecosystem_matrix_update_response_count }
-
-  it do
-    is_expected.to(
-      validate_numericality_of(:next_ecosystem_matrix_update_response_count).only_integer
-    )
-  end
 end

--- a/spec/models/exercise_group_spec.rb
+++ b/spec/models/exercise_group_spec.rb
@@ -3,9 +3,11 @@ require 'rails_helper'
 RSpec.describe ExerciseGroup, type: :model do
   subject { FactoryGirl.create :exercise_group }
 
-  it { is_expected.to have_many(:exercises).dependent(:destroy)              }
+  it { is_expected.to have_many(:exercises).dependent(:destroy)                          }
 
-  it { is_expected.to validate_presence_of(:response_count)                  }
+  it { is_expected.to validate_presence_of(:response_count)                              }
+  it { is_expected.to validate_presence_of(:next_update_response_count)                  }
 
-  it { is_expected.to validate_numericality_of(:response_count).only_integer }
+  it { is_expected.to validate_numericality_of(:response_count).only_integer             }
+  it { is_expected.to validate_numericality_of(:next_update_response_count).only_integer }
 end


### PR DESCRIPTION
This moves some expensive queries from the ecosystem_exercises table to the exercise_groups table, which is much smaller and can be kept in memory/cache.