### PR TITLE
Fix some deadlocks?

### DIFF
--- a/app/domain/services/update_clue_calculations/service.rb
+++ b/app/domain/services/update_clue_calculations/service.rb
@@ -4,13 +4,15 @@ class Services::UpdateClueCalculations::Service < Services::ApplicationService
 
     ActiveRecord::Base.transaction do
       student_clue_calculations_by_uuid = StudentClueCalculation
-                                            .where(uuid: relevant_calculation_uuids)
                                             .select(:uuid, :student_uuid, :algorithm_names)
+                                            .where(uuid: relevant_calculation_uuids)
+                                            .order(:student_uuid, :book_container_uuid)
                                             .lock('FOR NO KEY UPDATE')
                                             .index_by(&:uuid)
       teacher_clue_calculations_by_uuid = TeacherClueCalculation
-                                            .where(uuid: relevant_calculation_uuids)
                                             .select(:uuid, :algorithm_names)
+                                            .where(uuid: relevant_calculation_uuids)
+                                            .order(:course_container_uuid, :book_container_uuid)
                                             .lock('FOR NO KEY UPDATE')
                                             .index_by(&:uuid)
 

--- a/app/domain/services/update_exercise_calculations/service.rb
+++ b/app/domain/services/update_exercise_calculations/service.rb
@@ -3,8 +3,9 @@ class Services::UpdateExerciseCalculations::Service < Services::ApplicationServi
     calculation_uuids = exercise_calculation_updates.map { |calc| calc[:calculation_uuid] }
 
     ExerciseCalculation.transaction do
-      exercise_calculations_by_uuid = ExerciseCalculation.where(uuid: calculation_uuids)
-                                                         .select(:uuid, :algorithm_names)
+      exercise_calculations_by_uuid = ExerciseCalculation.select(:uuid, :algorithm_names)
+                                                         .where(uuid: calculation_uuids)
+                                                         .order(:student_uuid, :ecosystem_uuid)
                                                          .lock('FOR NO KEY UPDATE')
                                                          .index_by(&:uuid)
 


### PR DESCRIPTION
Lock CLUe and Exercise calculation records in the same order as the conflict index to hopefully fix some deadlocks