### PR TITLE
Order Courses, Ecosystems and ExerciseGroups by UUID when locking them

### DIFF
--- a/app/domain/services/fetch_course_events/service.rb
+++ b/app/domain/services/fetch_course_events/service.rb
@@ -28,7 +28,7 @@ class Services::FetchCourseEvents::Service < Services::ApplicationService
     # Query events for all courses in chunks
     loop do
       num_courses = Course.transaction do
-        course_relation = Course.order(:id).lock('FOR NO KEY UPDATE SKIP LOCKED')
+        course_relation = Course.order(:uuid).lock('FOR NO KEY UPDATE SKIP LOCKED')
         course_relation = course_relation.where(co[:id].gt(last_id)) unless last_id.nil?
         courses = course_relation.take(BATCH_SIZE)
         next 0 if courses.empty?

--- a/app/domain/services/fetch_ecosystem_events/service.rb
+++ b/app/domain/services/fetch_ecosystem_events/service.rb
@@ -20,7 +20,7 @@ class Services::FetchEcosystemEvents::Service < Services::ApplicationService
         # Since create_ecosystem is our only event here right now,
         # we can ignore all ecosystems that already processed it (sequence_number > 0)
         ecosystem_relation = Ecosystem.where(sequence_number: 0)
-                                      .order(:id)
+                                      .order(:uuid)
                                       .lock('FOR NO KEY UPDATE SKIP LOCKED')
         ecosystem_relation = ecosystem_relation.where(ec[:id].gt(last_id)) unless last_id.nil?
         ecosystems = ecosystem_relation.take(BATCH_SIZE)

--- a/app/domain/services/prepare_ecosystem_matrix_updates/service.rb
+++ b/app/domain/services/prepare_ecosystem_matrix_updates/service.rb
@@ -89,7 +89,7 @@ class Services::PrepareEcosystemMatrixUpdates::Service < Services::ApplicationSe
                 eex[:ecosystem_uuid].eq(ec[:uuid]).and(eg[:uuid].in(group_uuids))
               ).exists
             )
-            .order(:id)
+            .order(:uuid)
             .lock('FOR NO KEY UPDATE')
             .pluck(:uuid)
 
@@ -105,7 +105,7 @@ class Services::PrepareEcosystemMatrixUpdates::Service < Services::ApplicationSe
                 eex[:ecosystem_uuid].in(ecosystem_uuids).and(ex[:group_uuid].eq(eg[:uuid]))
               ).exists
             )
-            .order(:id)
+            .order(:uuid)
             .lock('FOR NO KEY UPDATE NOWAIT')
             .pluck(:uuid)
 


### PR DESCRIPTION
Since that is the order also used in the conflict index

Hopefully prevent more deadlocks