### PR TITLE
Fix another race condition

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ language: ruby
 rvm:
   - "2.3.3"
 addons:
-  postgresql: "9.5"
+  postgresql: "9.6"
 cache: bundler
 bundler_args: --without production --retry=6
 before_script:

--- a/app/domain/services/fetch_course_events/service.rb
+++ b/app/domain/services/fetch_course_events/service.rb
@@ -626,7 +626,7 @@ class Services::FetchCourseEvents::Service < Services::ApplicationService
     end
 
     AlgorithmExerciseCalculation.where(uuid: assignment_calc_uuids_to_recalculate)
-                                .update_all(is_uploaded_for_assignments: false) \
+                                .update_all(is_uploaded_for_assignment_uuids: []) \
       unless assignment_calc_uuids_to_recalculate.empty?
 
     results << Course.import(

--- a/app/domain/services/fetch_course_events/service.rb
+++ b/app/domain/services/fetch_course_events/service.rb
@@ -522,16 +522,16 @@ class Services::FetchCourseEvents::Service < Services::ApplicationService
       # Anti-cheating: we don't allow StudentPes that have already been assigned elsewhere
       # Recalculate Student PEs that conflict with the AssignedExercises that were just created
       AlgorithmExerciseCalculation
-        .joins(:student_pes, exercise_calculation: { assignments: :assigned_exercises })
+        .joins(:student_pes,
+               exercise_calculation: { student: { assignments: :assigned_exercises } })
         .where('"assigned_exercises"."exercise_uuid" = "student_pes"."exercise_uuid"')
         .where(assigned_exercises: { uuid: assigned_exercise_uuids })
         .update_all(is_uploaded_for_student: false)
 
-      # Recalculate Assignment PEs and SPEs that conflict
-      # with the AssignedExercises that were just created
-      # to prevent assignments with 2 copies of an exercise
+      # Recalculate Assignment PEs and SPEs that conflict with the AssignedExercises that were just
+      # created to prevent any assignment from getting a PE or SPE that was already used elsewhere
       AlgorithmExerciseCalculation
-        .joins(exercise_calculation: { assignments: :assigned_exercises })
+        .joins(exercise_calculation: { student: { assignments: :assigned_exercises } })
         .where(assigned_exercises: { uuid: assigned_exercise_uuids })
         .update_all(
           <<-UPDATE_SQL.strip_heredoc

--- a/app/domain/services/prepare_exercise_calculations/service.rb
+++ b/app/domain/services/prepare_exercise_calculations/service.rb
@@ -52,7 +52,7 @@ class Services::PrepareExerciseCalculations::Service < Services::ApplicationServ
             )
           )
           .joins(:student)
-          .need_spes_or_pes
+          .need_pes_or_spes
           .lock('FOR NO KEY UPDATE OF "students" SKIP LOCKED')
           .limit(BATCH_SIZE)
           .pluck('"students"."uuid"', :ecosystem_uuid)
@@ -117,7 +117,7 @@ class Services::PrepareExerciseCalculations::Service < Services::ApplicationServ
   def mark_assignments_with_calculations(ec, st, aa)
     # Check if any assignments with has_exercise_calculation: false
     # already have calculations and need to be updated
-    Assignment.joins(:student).need_spes_or_pes.where(has_exercise_calculation: false).where(
+    Assignment.joins(:student).need_pes_or_spes.where(has_exercise_calculation: false).where(
       ExerciseCalculation.where(
         ec[:student_uuid].eq(st[:uuid]).and ec[:ecosystem_uuid].eq(aa[:ecosystem_uuid])
       ).exists

--- a/app/domain/services/update_clue_calculations/service.rb
+++ b/app/domain/services/update_clue_calculations/service.rb
@@ -99,19 +99,17 @@ class Services::UpdateClueCalculations::Service < Services::ApplicationService
             StudentPe::CLUE_TO_EXERCISE_ALGORITHM_NAME[calculation.algorithm_name]
           ]
         end
-        student_pes_join_query = <<-JOIN_SQL.strip_heredoc
+        algorithm_exercise_calculation_join_query = <<-JOIN_SQL.strip_heredoc
           INNER JOIN (#{ValuesTable.new(student_pes_values_array)})
             AS "values" ("student_uuid", "algorithm_name")
               ON "exercise_calculations"."student_uuid" = "values"."student_uuid"
                 AND "algorithm_exercise_calculations"."algorithm_name" = "values"."algorithm_name"
         JOIN_SQL
 
-        StudentPe
-          .joins(algorithm_exercise_calculation: :exercise_calculation)
-          .joins(student_pes_join_query)
-          .order(:id)
-          .lock
-          .delete_all
+        AlgorithmExerciseCalculation
+          .joins(:exercise_calculation)
+          .joins(algorithm_exercise_calculation_join_query)
+          .update_all(is_uploaded_for_student: false)
       end
 
       { clue_calculation_update_responses: clue_calculation_update_responses }

--- a/app/domain/services/update_exercise_calculations/service.rb
+++ b/app/domain/services/update_exercise_calculations/service.rb
@@ -26,7 +26,7 @@ class Services::UpdateExerciseCalculations::Service < Services::ApplicationServi
             exercise_calculation: exercise_calculation,
             algorithm_name: algorithm_name,
             exercise_uuids: exercise_calculation_update.fetch(:exercise_uuids),
-            is_uploaded_for_assignments: false,
+            is_uploaded_for_assignment_uuids: [],
             is_uploaded_for_student: false
           )
 
@@ -41,7 +41,7 @@ class Services::UpdateExerciseCalculations::Service < Services::ApplicationServi
         algorithm_exercise_calculations, validate: false, on_duplicate_key_update: {
           conflict_target: [ :exercise_calculation_uuid, :algorithm_name ],
           columns: [
-            :uuid, :exercise_uuids, :is_uploaded_for_assignments, :is_uploaded_for_student
+            :uuid, :exercise_uuids, :is_uploaded_for_assignment_uuids, :is_uploaded_for_student
           ]
         }
       )

--- a/app/domain/services/update_exercise_calculations/service.rb
+++ b/app/domain/services/update_exercise_calculations/service.rb
@@ -56,7 +56,7 @@ class Services::UpdateExerciseCalculations::Service < Services::ApplicationServi
 
       # Cleanup AssignmentSpes, AssignmentPes and StudentPes that no longer have
       # an associated AlgorithmExerciseCalculation record
-      AssignmentPe.unassociated.delete_all
+      AssignmentPe.where(id: AssignmentPe.unassociated.order(:id).lock).delete_all
       AssignmentSpe.where(id: AssignmentSpe.unassociated.order(:id).lock).delete_all
       StudentPe.where(id: StudentPe.unassociated.order(:id).lock).delete_all
 

--- a/app/domain/services/update_student_history/service.rb
+++ b/app/domain/services/update_student_history/service.rb
@@ -73,7 +73,7 @@ class Services::UpdateStudentHistory::Service < Services::ApplicationService
         AlgorithmExerciseCalculation
           .joins(exercise_calculation: :assignments)
           .where(assignments: { student_uuid: completed_assignment_student_uuids })
-          .update_all(is_uploaded_for_assignments: false)
+          .update_all(is_uploaded_for_assignment_uuids: [])
 
         AssignmentSpe.joins(:assignment)
                      .where(assignments: { student_uuid: completed_assignment_student_uuids })
@@ -117,7 +117,7 @@ class Services::UpdateStudentHistory::Service < Services::ApplicationService
         AlgorithmExerciseCalculation
           .joins(exercise_calculation: :assignments)
           .where(assignments: { student_uuid: due_assignment_student_uuids })
-          .update_all(is_uploaded_for_assignments: false)
+          .update_all(is_uploaded_for_assignment_uuids: [])
 
         AssignmentSpe.joins(:assignment)
                      .where(assignments: { student_uuid: due_assignment_student_uuids })

--- a/app/domain/services/update_student_history/service.rb
+++ b/app/domain/services/update_student_history/service.rb
@@ -68,18 +68,11 @@ class Services::UpdateStudentHistory::Service < Services::ApplicationService
           SQL
         )
 
-        # Recalculate SPEs for affected students
-        completed_assignment_student_uuids = completed_assignments.map(&:student_uuid)
+        # Recalculate all SPEs for affected students
         AlgorithmExerciseCalculation
           .joins(exercise_calculation: :assignments)
-          .where(assignments: { student_uuid: completed_assignment_student_uuids })
+          .where(assignments: { student_uuid: completed_assignments.map(&:student_uuid) })
           .update_all(is_uploaded_for_assignment_uuids: [])
-
-        AssignmentSpe.joins(:assignment)
-                     .where(assignments: { student_uuid: completed_assignment_student_uuids })
-                     .order(:id)
-                     .lock
-                     .delete_all
 
         num_responses
       end
@@ -113,17 +106,11 @@ class Services::UpdateStudentHistory::Service < Services::ApplicationService
         due_assignment_uuids = due_assignments.map(&:uuid)
         Assignment.where(uuid: due_assignment_uuids).update_all('"student_history_at" = "due_at"')
 
-        due_assignment_student_uuids = due_assignments.map(&:student_uuid)
+        # Recalculate all SPEs for affected students
         AlgorithmExerciseCalculation
           .joins(exercise_calculation: :assignments)
-          .where(assignments: { student_uuid: due_assignment_student_uuids })
+          .where(assignments: { student_uuid: due_assignments.map(&:student_uuid) })
           .update_all(is_uploaded_for_assignment_uuids: [])
-
-        AssignmentSpe.joins(:assignment)
-                     .where(assignments: { student_uuid: due_assignment_student_uuids })
-                     .order(:id)
-                     .lock
-                     .delete_all
 
         due_assignments.size
       end

--- a/app/domain/services/upload_assignment_exercises/service.rb
+++ b/app/domain/services/upload_assignment_exercises/service.rb
@@ -75,7 +75,9 @@ class Services::UploadAssignmentExercises::Service < Services::ApplicationServic
                   "values"."algorithm_exercise_calculation_uuid"
             )
           WHERE_SQL
-          AssignmentPe.where(assignment_pe_where_query).delete_all
+          AssignmentPe.where(
+            id: AssignmentPe.where(assignment_pe_where_query).order(:id).lock
+          ).delete_all
         end
         spe_assignments = assignments.select(&:needs_spes?)
         unless spe_assignments.empty?
@@ -93,7 +95,9 @@ class Services::UploadAssignmentExercises::Service < Services::ApplicationServic
                   "values"."algorithm_exercise_calculation_uuid"
             )
           WHERE_SQL
-          AssignmentSpe.where(assignment_spe_where_query).delete_all
+          AssignmentSpe.where(
+            id: AssignmentSpe.where(assignment_spe_where_query).order(:id).lock
+          ).delete_all
         end
 
         spe_student_uuids = spe_assignments.map(&:student_uuid)

--- a/app/domain/services/upload_assignment_exercises/service.rb
+++ b/app/domain/services/upload_assignment_exercises/service.rb
@@ -37,7 +37,7 @@ class Services::UploadAssignmentExercises::Service < Services::ApplicationServic
             .where.not(
               <<-NOT_SQL.strip_heredoc
                 "algorithm_exercise_calculations"."is_uploaded_for_assignment_uuids" @>
-                ARRAY["assignments"."uuid"]
+                ARRAY["assignments"."uuid"::varchar]
               NOT_SQL
             ).exists
           )
@@ -54,7 +54,7 @@ class Services::UploadAssignmentExercises::Service < Services::ApplicationServic
           .where.not(
             <<-NOT_SQL.strip_heredoc
               "algorithm_exercise_calculations"."is_uploaded_for_assignment_uuids" @>
-              ARRAY["assignments"."uuid"]
+              ARRAY["assignments"."uuid"::varchar]
             NOT_SQL
           )
 

--- a/app/domain/services/upload_assignment_exercises/service.rb
+++ b/app/domain/services/upload_assignment_exercises/service.rb
@@ -17,6 +17,7 @@ class Services::UploadAssignmentExercises::Service < Services::ApplicationServic
     log(:debug) { "Started at #{start_time}" }
 
     aa = Assignment.arel_table
+    ec = ExerciseCalculation.arel_table
     aec = AlgorithmExerciseCalculation.arel_table
     ape = AssignmentPe.arel_table
     aspe = AssignmentSpe.arel_table
@@ -26,40 +27,74 @@ class Services::UploadAssignmentExercises::Service < Services::ApplicationServic
       num_algorithm_exercise_calculations = AlgorithmExerciseCalculation.transaction do
         # Find algorithm_exercise_calculations with assignments that need PEs or SPEs
         algorithm_exercise_calculations_by_uuid = AlgorithmExerciseCalculation
-          .select([:uuid, :algorithm_name, :exercise_uuids])
-          .where(is_uploaded_for_assignments: false)
+          .joins(:exercise_calculation)
+          .where(
+            Assignment.need_pes_or_spes.where(
+              aa[:student_uuid].eq(ec[:student_uuid]).and(
+                aa[:ecosystem_uuid].eq(ec[:ecosystem_uuid])
+              )
+            )
+            .where.not(
+              <<-NOT_SQL.strip_heredoc
+                "algorithm_exercise_calculations"."is_uploaded_for_assignment_uuids" @>
+                ARRAY["assignments"."uuid"]
+              NOT_SQL
+            ).exists
+          )
           .lock('FOR NO KEY UPDATE SKIP LOCKED')
           .limit(BATCH_SIZE)
           .index_by(&:uuid)
         algorithm_exercise_calculation_uuids = algorithm_exercise_calculations_by_uuid.keys
 
-        pe_assignments = Assignment
-          .need_pes
+        assignments = Assignment
+          .need_pes_or_spes
           .select([ aa[Arel.star], aec[:uuid].as('algorithm_exercise_calculation_uuid') ])
           .joins(exercise_calculation: :algorithm_exercise_calculations)
           .where(algorithm_exercise_calculations: { uuid: algorithm_exercise_calculation_uuids })
-          .where(
-            AssignmentPe.where(
-              ape[:assignment_uuid].eq(aa[:uuid]).and(
-                ape[:algorithm_exercise_calculation_uuid].eq aec[:uuid]
-              )
-            ).exists.not
+          .where.not(
+            <<-NOT_SQL.strip_heredoc
+              "algorithm_exercise_calculations"."is_uploaded_for_assignment_uuids" @>
+              ARRAY["assignments"."uuid"]
+            NOT_SQL
           )
 
-        spe_assignments = Assignment
-          .need_spes
-          .select([ aa[Arel.star], aec[:uuid].as('algorithm_exercise_calculation_uuid') ])
-          .joins(exercise_calculation: :algorithm_exercise_calculations)
-          .where(algorithm_exercise_calculations: { uuid: algorithm_exercise_calculation_uuids })
-          .where(
-            AssignmentSpe.where(
-              aspe[:assignment_uuid].eq(aa[:uuid]).and(
-                aspe[:algorithm_exercise_calculation_uuid].eq aec[:uuid]
-              )
-            ).exists.not
-          )
-
-        assignments = (pe_assignments + spe_assignments).uniq
+        # Delete relevant AssignmentPe and AssignmentSpes, since we are about to reupload them
+        pe_assignments = assignments.select(&:needs_pes?)
+        unless pe_assignments.empty?
+          assignment_pe_values = pe_assignments.map do |pe_assignment|
+            [ pe_assignment.uuid, pe_assignment.algorithm_exercise_calculation_uuid ]
+          end
+          assignment_pe_where_query = <<-WHERE_SQL.strip_heredoc
+            "assignment_pes"."id" IN (
+              SELECT "assignment_pes"."id"
+              FROM "assignment_pes"
+              INNER JOIN (#{ValuesTable.new(assignment_pe_values)}) AS "values"
+                ("assignment_uuid", "algorithm_exercise_calculation_uuid")
+                ON "assignment_pes"."assignment_uuid" = "values"."assignment_uuid"
+                AND "assignment_pes"."algorithm_exercise_calculation_uuid" =
+                  "values"."algorithm_exercise_calculation_uuid"
+            )
+          WHERE_SQL
+          AssignmentPe.where(assignment_pe_where_query).delete_all
+        end
+        spe_assignments = assignments.select(&:needs_spes?)
+        unless spe_assignments.empty?
+          assignment_spe_values = spe_assignments.map do |spe_assignment|
+            [ spe_assignment.uuid, spe_assignment.algorithm_exercise_calculation_uuid ]
+          end
+          assignment_spe_where_query = <<-WHERE_SQL.strip_heredoc
+            "assignment_spes"."id" IN (
+              SELECT "assignment_spes"."id"
+              FROM "assignment_spes"
+              INNER JOIN (#{ValuesTable.new(assignment_spe_values)}) AS "values"
+                ("assignment_uuid", "algorithm_exercise_calculation_uuid")
+                ON "assignment_spes"."assignment_uuid" = "values"."assignment_uuid"
+                AND "assignment_spes"."algorithm_exercise_calculation_uuid" =
+                  "values"."algorithm_exercise_calculation_uuid"
+            )
+          WHERE_SQL
+          AssignmentSpe.where(assignment_spe_where_query).delete_all
+        end
 
         spe_student_uuids = spe_assignments.map(&:student_uuid)
         spe_assignment_types = spe_assignments.map(&:assignment_type)
@@ -536,10 +571,18 @@ class Services::UploadAssignmentExercises::Service < Services::ApplicationServic
         end
 
         # Mark the AlgorithmExerciseCalculations as uploaded
-        AlgorithmExerciseCalculation.where(uuid: algorithm_exercise_calculation_uuids)
-                                    .update_all(is_uploaded_for_assignments: true)
+        assignments.each do |assignment|
+          algorithm_exercise_calculation =
+            algorithm_exercise_calculations_by_uuid[assignment.algorithm_exercise_calculation_uuid]
+          algorithm_exercise_calculation.is_uploaded_for_assignment_uuids << assignment.uuid
+        end
+        algorithm_exercise_calculations = algorithm_exercise_calculations_by_uuid.values
+        AlgorithmExerciseCalculation.import algorithm_exercise_calculations,
+                                            validate: false, on_duplicate_key_update: {
+          conflict_target: [ :id ], columns: [ :is_uploaded_for_assignment_uuids ]
+        }
 
-        algorithm_exercise_calculation_uuids.size
+        algorithm_exercise_calculations.size
       end
 
       # If we got less records than both batch sizes, then this is the last batch

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -22,15 +22,6 @@ class Assignment < ApplicationRecord
                        optional: true,
                        inverse_of: :assignments
 
-  scope :need_spes, -> do
-    where(
-      arel_table[:spes_are_assigned].eq(false).and(
-        arel_table[:goal_num_tutor_assigned_spes].eq(nil).or(
-          arel_table[:goal_num_tutor_assigned_spes].gt(0)
-        )
-      )
-    )
-  end
   scope :need_pes, -> do
     where(
       arel_table[:pes_are_assigned].eq(false).and(
@@ -40,8 +31,24 @@ class Assignment < ApplicationRecord
       )
     )
   end
-  scope :need_spes_or_pes, -> do
-    need_spes.or(need_pes)
+  scope :need_spes, -> do
+    where(
+      arel_table[:spes_are_assigned].eq(false).and(
+        arel_table[:goal_num_tutor_assigned_spes].eq(nil).or(
+          arel_table[:goal_num_tutor_assigned_spes].gt(0)
+        )
+      )
+    )
+  end
+  scope :need_pes_or_spes, -> do
+    need_pes.or(need_spes)
+  end
+
+  def needs_pes?
+    !pes_are_assigned && (goal_num_tutor_assigned_pes.nil? || goal_num_tutor_assigned_pes > 0)
+  end
+  def needs_spes?
+    !spes_are_assigned && (goal_num_tutor_assigned_spes.nil? || goal_num_tutor_assigned_spes > 0)
   end
 
   # https://blog.codeship.com/folding-postgres-window-functions-into-rails/

--- a/db/migrate/20180907195330_change_aec_is_uploaded_for_assignments_to_uuid_array.rb
+++ b/db/migrate/20180907195330_change_aec_is_uploaded_for_assignments_to_uuid_array.rb
@@ -1,0 +1,42 @@
+class ChangeAecIsUploadedForAssignmentsToUuidArray < ActiveRecord::Migration[5.0]
+  def up
+    add_column :algorithm_exercise_calculations, :is_uploaded_for_assignment_uuids, :uuid,
+               array: true, null: false, default: []
+
+    AlgorithmExerciseCalculation.where(is_uploaded_for_assignments: true).update_all(
+      <<-UPDATE_SQL.strip_heredoc
+        "is_uploaded_for_assignment_uuids" = (
+          SELECT ARRAY_AGG("assignments"."uuid")
+          FROM "assignments"
+          INNER JOIN "exercise_calculations"
+            ON "exercise_calculations"."student_uuid" = "assignments"."student_uuid"
+            AND "exercise_calculations"."ecosystem_uuid" = "assignments"."ecosystem_uuid"
+          WHERE "exercise_calculations"."uuid" =
+            "algorithm_exercise_calculations"."exercise_calculation_uuid"
+        )
+      UPDATE_SQL
+    )
+
+    add_index :algorithm_exercise_calculations, :is_uploaded_for_assignment_uuids, using: :gin,
+              name: 'index_alg_ex_calc_on_is_uploaded_for_assignment_uuids'
+
+    remove_column :algorithm_exercise_calculations, :is_uploaded_for_assignments
+
+    change_column_null :algorithm_exercise_calculations, :is_uploaded_for_student, false
+  end
+
+  def down
+    change_column_null :algorithm_exercise_calculations, :is_uploaded_for_student, true
+
+    add_column :algorithm_exercise_calculations, :is_uploaded_for_assignments, :boolean
+
+    AlgorithmExerciseCalculation.update_all(
+      "is_uploaded_for_assignments = (is_uploaded_for_assignment_uuids != '{}')"
+    )
+
+    add_index :algorithm_exercise_calculations, :is_uploaded_for_assignments,
+              name: 'index_alg_ex_calc_on_is_uploaded_for_assignments'
+
+    remove_column :algorithm_exercise_calculations, :is_uploaded_for_assignment_uuids
+  end
+end

--- a/db/migrate/20180907195330_change_aec_is_uploaded_for_assignments_to_uuid_array.rb
+++ b/db/migrate/20180907195330_change_aec_is_uploaded_for_assignments_to_uuid_array.rb
@@ -1,6 +1,6 @@
 class ChangeAecIsUploadedForAssignmentsToUuidArray < ActiveRecord::Migration[5.0]
   def up
-    add_column :algorithm_exercise_calculations, :is_uploaded_for_assignment_uuids, :uuid,
+    add_column :algorithm_exercise_calculations, :is_uploaded_for_assignment_uuids, :string,
                array: true, null: false, default: []
 
     AlgorithmExerciseCalculation.where(is_uploaded_for_assignments: true).update_all(

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -34,7 +34,7 @@ ActiveRecord::Schema.define(version: 20180907195330) do
     t.datetime "created_at",                                    null: false
     t.datetime "updated_at",                                    null: false
     t.boolean  "is_uploaded_for_student",                       null: false
-    t.uuid     "is_uploaded_for_assignment_uuids", default: [], null: false, array: true
+    t.string   "is_uploaded_for_assignment_uuids", default: [], null: false, array: true
     t.index ["exercise_calculation_uuid", "algorithm_name"], name: "index_alg_ex_calc_on_ex_calc_uuid_and_alg_name", unique: true, using: :btree
     t.index ["is_uploaded_for_assignment_uuids"], name: "index_alg_ex_calc_on_is_uploaded_for_assignment_uuids", using: :gin
     t.index ["is_uploaded_for_student"], name: "index_alg_ex_calc_on_is_uploaded_for_student", using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180320200143) do
+ActiveRecord::Schema.define(version: 20180907195330) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -27,16 +27,16 @@ ActiveRecord::Schema.define(version: 20180320200143) do
   end
 
   create_table "algorithm_exercise_calculations", force: :cascade do |t|
-    t.uuid     "uuid",                        null: false
-    t.uuid     "exercise_calculation_uuid",   null: false
-    t.citext   "algorithm_name",              null: false
-    t.uuid     "exercise_uuids",              null: false, array: true
-    t.datetime "created_at",                  null: false
-    t.datetime "updated_at",                  null: false
-    t.boolean  "is_uploaded_for_assignments"
-    t.boolean  "is_uploaded_for_student"
+    t.uuid     "uuid",                                          null: false
+    t.uuid     "exercise_calculation_uuid",                     null: false
+    t.citext   "algorithm_name",                                null: false
+    t.uuid     "exercise_uuids",                                null: false, array: true
+    t.datetime "created_at",                                    null: false
+    t.datetime "updated_at",                                    null: false
+    t.boolean  "is_uploaded_for_student",                       null: false
+    t.uuid     "is_uploaded_for_assignment_uuids", default: [], null: false, array: true
     t.index ["exercise_calculation_uuid", "algorithm_name"], name: "index_alg_ex_calc_on_ex_calc_uuid_and_alg_name", unique: true, using: :btree
-    t.index ["is_uploaded_for_assignments"], name: "index_alg_ex_calc_on_is_uploaded_for_assignments", using: :btree
+    t.index ["is_uploaded_for_assignment_uuids"], name: "index_alg_ex_calc_on_is_uploaded_for_assignment_uuids", using: :gin
     t.index ["is_uploaded_for_student"], name: "index_alg_ex_calc_on_is_uploaded_for_student", using: :btree
     t.index ["uuid"], name: "index_algorithm_exercise_calculations_on_uuid", unique: true, using: :btree
   end

--- a/spec/domain/services/fetch_course_events/service_spec.rb
+++ b/spec/domain/services/fetch_course_events/service_spec.rb
@@ -455,8 +455,9 @@ RSpec.describe Services::FetchCourseEvents::Service, type: :service do
       end
 
       context 'with an existing assignment with SPE/PE calculations and associated records' do
+        let(:ecosystem)                      { FactoryGirl.create :ecosystem, uuid: ecosystem_uuid }
         let(:exercise_calculation)           do
-          FactoryGirl.create :exercise_calculation, student: student
+          FactoryGirl.create :exercise_calculation, student: student, ecosystem: ecosystem
         end
         let!(:existing_assignment)           do
           FactoryGirl.create :assignment, uuid: assignment_uuid, student_uuid: student_uuid

--- a/spec/domain/services/fetch_course_events/service_spec.rb
+++ b/spec/domain/services/fetch_course_events/service_spec.rb
@@ -458,14 +458,14 @@ RSpec.describe Services::FetchCourseEvents::Service, type: :service do
         let(:exercise_calculation)           do
           FactoryGirl.create :exercise_calculation, student: student
         end
+        let!(:existing_assignment)           do
+          FactoryGirl.create :assignment, uuid: assignment_uuid, student_uuid: student_uuid
+        end
         let(:algorithm_exercise_calculation) do
           FactoryGirl.create :algorithm_exercise_calculation,
             exercise_calculation: exercise_calculation,
             is_uploaded_for_student: true,
-            is_uploaded_for_assignments: true
-        end
-        let!(:existing_assignment)           do
-          FactoryGirl.create :assignment, uuid: assignment_uuid, student_uuid: student_uuid
+            is_uploaded_for_assignment_uuids: [ existing_assignment.uuid ]
         end
         let!(:existing_assignment_pes)       do
           assigned_exercise_uuids.map do |assigned_exercise_uuid|
@@ -526,7 +526,7 @@ RSpec.describe Services::FetchCourseEvents::Service, type: :service do
 
           algorithm_exercise_calculation.reload
           expect(algorithm_exercise_calculation.is_uploaded_for_student).to eq false
-          expect(algorithm_exercise_calculation.is_uploaded_for_assignments).to eq false
+          expect(algorithm_exercise_calculation.is_uploaded_for_assignment_uuids).to eq []
         end
       end
     end

--- a/spec/domain/services/update_student_history/service_spec.rb
+++ b/spec/domain/services/update_student_history/service_spec.rb
@@ -411,9 +411,18 @@ RSpec.describe Services::UpdateStudentHistory::Service, type: :service do
         pes_are_assigned: false
       )
 
-      [ @reading_1, @homework_1 ].each do |assignment|
-        FactoryGirl.create :assignment_spe, assignment: assignment
-      end
+      @exercise_calculation_1 = FactoryGirl.create :exercise_calculation,
+                                                   student_uuid: student.uuid,
+                                                   ecosystem_uuid: ecosystem_1.uuid
+      @exercise_calculation_2 = FactoryGirl.create :exercise_calculation,
+                                                   student_uuid: student.uuid,
+                                                   ecosystem_uuid: ecosystem_2.uuid
+
+      @aec_1 = FactoryGirl.create :algorithm_exercise_calculation,
+                                  exercise_calculation: @exercise_calculation_1,
+                                  is_uploaded_for_assignment_uuids: [ @reading_1.uuid ]
+      @aec_2 = FactoryGirl.create :algorithm_exercise_calculation,
+                                  exercise_calculation: @exercise_calculation_2
     end
 
     after(:all)  { DatabaseCleaner.clean }
@@ -457,7 +466,9 @@ RSpec.describe Services::UpdateStudentHistory::Service, type: :service do
 
       it 'adds the assignments to the student history in the correct order' do
         expect { subject.process }.to  not_change { Assignment.count }
-                                  .and change     { AssignmentSpe.count }.by(-2)
+                                  .and not_change { AssignmentSpe.count  }
+                                  .and     change { @aec_1.reload.is_uploaded_for_assignment_uuids }
+                                  .and not_change { @aec_2.reload.is_uploaded_for_assignment_uuids }
 
         student_history_assignments = Assignment
           .where(uuid: all_assignment_uuids)
@@ -483,7 +494,9 @@ RSpec.describe Services::UpdateStudentHistory::Service, type: :service do
 
       it 'adds the assignments to the student history in the correct order' do
         expect { subject.process }.to  not_change { Assignment.count }
-                                  .and change     { AssignmentSpe.count }.by(-2)
+                                  .and not_change { AssignmentSpe.count  }
+                                  .and     change { @aec_1.reload.is_uploaded_for_assignment_uuids }
+                                  .and not_change { @aec_2.reload.is_uploaded_for_assignment_uuids }
 
         student_history_assignments = Assignment
           .where(uuid: all_assignment_uuids)
@@ -509,7 +522,9 @@ RSpec.describe Services::UpdateStudentHistory::Service, type: :service do
 
       it 'adds the assignments to the student history in the correct order' do
         expect { subject.process }.to  not_change { Assignment.count }
-                                  .and change { AssignmentSpe.count }.by(-2)
+                                  .and not_change { AssignmentSpe.count  }
+                                  .and     change { @aec_1.reload.is_uploaded_for_assignment_uuids }
+                                  .and not_change { @aec_2.reload.is_uploaded_for_assignment_uuids }
 
         student_history_assignments = Assignment
           .where(uuid: all_assignment_uuids)
@@ -543,7 +558,9 @@ RSpec.describe Services::UpdateStudentHistory::Service, type: :service do
 
       it 'adds the assignments to the student history in the correct order' do
         expect { subject.process }.to  not_change { Assignment.count }
-                                  .and change     { AssignmentSpe.count }.by(-2)
+                                  .and not_change { AssignmentSpe.count  }
+                                  .and     change { @aec_1.reload.is_uploaded_for_assignment_uuids }
+                                  .and not_change { @aec_2.reload.is_uploaded_for_assignment_uuids }
 
         student_history_assignments = Assignment
           .where(uuid: all_assignment_uuids)

--- a/spec/domain/services/upload_assignment_exercises/service_spec.rb
+++ b/spec/domain/services/upload_assignment_exercises/service_spec.rb
@@ -446,8 +446,7 @@ RSpec.describe Services::UploadAssignmentExercises::Service, type: :service do
       @algorithm_exercise_calculation_1 = FactoryGirl.create(
         :algorithm_exercise_calculation,
         exercise_calculation: exercise_calculation_1,
-        exercise_uuids: old_exercise_uuids.shuffle,
-        is_uploaded_for_assignments: false
+        exercise_uuids: old_exercise_uuids.shuffle
       )
 
       exercise_calculation_2 = FactoryGirl.create(
@@ -458,8 +457,7 @@ RSpec.describe Services::UploadAssignmentExercises::Service, type: :service do
       @algorithm_exercise_calculation_2 = FactoryGirl.create(
         :algorithm_exercise_calculation,
         exercise_calculation: exercise_calculation_2,
-        exercise_uuids: new_exercise_uuids.shuffle,
-        is_uploaded_for_assignments: false
+        exercise_uuids: new_exercise_uuids.shuffle
       )
     end
 

--- a/spec/factories/algorithm_exercise_calculations.rb
+++ b/spec/factories/algorithm_exercise_calculations.rb
@@ -1,12 +1,12 @@
 FactoryGirl.define do
   factory :algorithm_exercise_calculation do
-    transient                   { num_exercise_uuids { rand(10) + 1 } }
+    transient                        { num_exercise_uuids { rand(10) + 1 } }
 
-    uuid                        { SecureRandom.uuid }
+    uuid                             { SecureRandom.uuid }
     exercise_calculation
-    algorithm_name              { [ 'local_query', 'tesr' ].sample }
-    exercise_uuids              { num_exercise_uuids.times.map { SecureRandom.uuid } }
-    is_uploaded_for_assignments { [ true, false ].sample }
-    is_uploaded_for_student     { [ true, false ].sample }
+    algorithm_name                   { [ 'local_query', 'tesr' ].sample }
+    exercise_uuids                   { num_exercise_uuids.times.map { SecureRandom.uuid } }
+    is_uploaded_for_assignment_uuids { [] }
+    is_uploaded_for_student          { [ true, false ].sample }
   end
 end


### PR DESCRIPTION
This fixes a race condition where biglearn-scheduler would fail to upload the PEs/SPEs for an assignment if it and its calculation were created at the same time.

Main change is to replace the `is_uploaded_for_assignments` boolean column with an uuid[] column and then use it everywhere (actually I used a string[] because Postgres < 10 lacks support for uuid[] indices).

Also fixes an issue where "Practice Worst Areas" was not being updated properly when the CLUes change.