### PR TITLE
Fix deadlock on exercise_calculations

### DIFF
--- a/app/domain/services/prepare_exercise_calculations/service.rb
+++ b/app/domain/services/prepare_exercise_calculations/service.rb
@@ -79,7 +79,7 @@ class Services::PrepareExerciseCalculations::Service < Services::ApplicationServ
             ecosystem_uuid: ecosystem_uuid,
             student_uuid: student_uuid
           )
-        end
+        end.sort_by { |calc| [ calc.student_uuid, calc.ecosystem_uuid ] }
 
         # Record the ExerciseCalculations
         ExerciseCalculation.import(


### PR DESCRIPTION
```
Process 81749 waits for ShareLock on transaction 678235586; blocked by process 114686.
Process 114686 waits for ShareLock on transaction 678235658; blocked by process 81749.
Process 81749: SELECT "exercise_calculations"."uuid", "exercise_calculations"."algorithm_names" FROM "exercise_calculations" WHERE "exercise_calculations"."uuid" IN ('8f442ca1-b66e-4f72-bc4b-ec026b4bf549', '8b3d5678-c53a-4f80-a43f-6138d473f2b7', '50e8e6f7-b300-4941-9114-2498966a03fd', '8191381e-f26e-48af-9977-75897299cef2', 'f353c08d-5e0f-49a4-bd78-a58c1b561569') ORDER BY "exercise_calculations"."student_uuid" ASC, "exercise_calculations"."ecosystem_uuid" ASC FOR NO KEY UPDATE
Process 114686: INSERT INTO "exercise_calculations" ("id","uuid","ecosystem_uuid","student_uuid","created_at","updated_at","algorithm_names") VALUES (nextval('public.exercise_calculations_id_seq'),'724b3943-f2bb-4a60-8566-87c0e9235b8f','e6fb4ca9-1efb-499b-a763-b9509fef8521','16d3b42f-f907-4086-baef-a6bd59ef972b','2018-10-01 13:43:49.238056','2018-10-01 13:43:49.238086','{}'),(nextval('public.exercise_calculations_id_seq'),'66d0cef5-f74a-45bd-a0fb-16ffc9713d60','406be20f-16cb-49d2-baa2-57a20bcc7bee','16d3b42f-f907-4086-baef-a6bd59ef972b','2018-10-01 13:43:49.238056','2018-10-01 13:43:49.238086','{}') ON CONFLICT (student_uuid, ecosystem_uuid) DO UPDATE SET "uuid"=EXCLUDED."uuid","algorithm_names"=EXCLUDED."algorithm_names","updated_at"=EXCLUDED."updated_at" RETURNING "id"
```

The select for update and upsert on exercise_calculations seemed to be happening in different order. Fixed by ordering the records to be upserted to match the select for update.

Does not seem to be testable because the deadlock happened within 2 single queries, not a transaction.