### PR TITLE
More deadlock fixes

### DIFF
--- a/app/domain/services/ecosystem_matrices_updated/service.rb
+++ b/app/domain/services/ecosystem_matrices_updated/service.rb
@@ -2,11 +2,12 @@ class Services::EcosystemMatricesUpdated::Service < Services::ApplicationService
   def process(ecosystem_matrices_updated:)
     relevant_update_uuids = ecosystem_matrices_updated.map { |update| update[:calculation_uuid] }
     EcosystemMatrixUpdate.transaction do
-      ecosystem_matrix_updates_by_uuid = EcosystemMatrixUpdate.select(:uuid, :algorithm_names)
-                                                              .where(uuid: relevant_update_uuids)
-                                                              .ordered
-                                                              .lock('FOR NO KEY UPDATE')
-                                                              .index_by(&:uuid)
+      ecosystem_matrix_updates_by_uuid = EcosystemMatrixUpdate
+        .select(:uuid, :ecosystem_uuid, :algorithm_names)
+        .where(uuid: relevant_update_uuids)
+        .ordered
+        .lock('FOR NO KEY UPDATE')
+        .index_by(&:uuid)
 
       algorithm_ecosystem_matrix_updates = []
       ecosystem_matrix_update_uuids_by_algorithm_names = Hash.new { |hash, key| hash[key] = [] }

--- a/app/domain/services/update_clue_calculations/service.rb
+++ b/app/domain/services/update_clue_calculations/service.rb
@@ -4,17 +4,17 @@ class Services::UpdateClueCalculations::Service < Services::ApplicationService
 
     ActiveRecord::Base.transaction do
       student_clue_calculations_by_uuid = StudentClueCalculation
-                                            .select(:uuid, :student_uuid, :algorithm_names)
-                                            .where(uuid: relevant_calculation_uuids)
-                                            .ordered
-                                            .lock('FOR NO KEY UPDATE')
-                                            .index_by(&:uuid)
+        .select(:uuid, :student_uuid, :book_container_uuid, :algorithm_names)
+        .where(uuid: relevant_calculation_uuids)
+        .ordered
+        .lock('FOR NO KEY UPDATE')
+        .index_by(&:uuid)
       teacher_clue_calculations_by_uuid = TeacherClueCalculation
-                                            .select(:uuid, :algorithm_names)
-                                            .where(uuid: relevant_calculation_uuids)
-                                            .ordered
-                                            .lock('FOR NO KEY UPDATE')
-                                            .index_by(&:uuid)
+        .select(:uuid, :course_container_uuid, :book_container_uuid, :algorithm_names)
+        .where(uuid: relevant_calculation_uuids)
+        .ordered
+        .lock('FOR NO KEY UPDATE')
+        .index_by(&:uuid)
 
       algorithm_student_clue_calculations = []
       algorithm_teacher_clue_calculations = []

--- a/app/domain/services/update_exercise_calculations/service.rb
+++ b/app/domain/services/update_exercise_calculations/service.rb
@@ -3,11 +3,12 @@ class Services::UpdateExerciseCalculations::Service < Services::ApplicationServi
     calculation_uuids = exercise_calculation_updates.map { |calc| calc[:calculation_uuid] }
 
     ExerciseCalculation.transaction do
-      exercise_calculations_by_uuid = ExerciseCalculation.select(:uuid, :algorithm_names)
-                                                         .where(uuid: calculation_uuids)
-                                                         .ordered
-                                                         .lock('FOR NO KEY UPDATE')
-                                                         .index_by(&:uuid)
+      exercise_calculations_by_uuid = ExerciseCalculation
+        .select(:uuid, :student_uuid, :ecosystem_uuid, :algorithm_names)
+        .where(uuid: calculation_uuids)
+        .ordered
+        .lock('FOR NO KEY UPDATE')
+        .index_by(&:uuid)
 
       algorithm_exercise_calculations = []
       exercise_calculation_uuids_by_algorithm_names = Hash.new { |hash, key| hash[key] = [] }

--- a/app/models/algorithm_ecosystem_matrix_update.rb
+++ b/app/models/algorithm_ecosystem_matrix_update.rb
@@ -3,7 +3,7 @@ class AlgorithmEcosystemMatrixUpdate < ApplicationRecord
                                        foreign_key: :ecosystem_matrix_update_uuid,
                                        inverse_of: :algorithm_ecosystem_matrix_updates
 
-  unique_index :ecosystem_matrix_update_uuid, :algorithm_name
+  unique_index :ecosystem_matrix_update_uuid, :algorithm_name, scoped_to: :ecosystem_matrix_update
 
   scope :unassociated, -> do
     where.not(

--- a/app/models/algorithm_exercise_calculation.rb
+++ b/app/models/algorithm_exercise_calculation.rb
@@ -16,7 +16,7 @@ class AlgorithmExerciseCalculation < ApplicationRecord
                                     foreign_key: :exercise_calculation_uuid,
                                     inverse_of: :algorithm_exercise_calculations
 
-  unique_index :exercise_calculation_uuid, :algorithm_name
+  unique_index :exercise_calculation_uuid, :algorithm_name, scoped_to: :exercise_calculation
 
   validates :exercise_uuids, presence: true
 

--- a/app/models/algorithm_student_clue_calculation.rb
+++ b/app/models/algorithm_student_clue_calculation.rb
@@ -3,7 +3,7 @@ class AlgorithmStudentClueCalculation < ApplicationRecord
                                         foreign_key: :student_clue_calculation_uuid,
                                         inverse_of: :algorithm_student_clue_calculations
 
-  unique_index :student_clue_calculation_uuid, :algorithm_name
+  unique_index :student_clue_calculation_uuid, :algorithm_name, scoped_to: :student_clue_calculation
 
   validates :clue_data, presence: true
   validates :clue_value, presence: true

--- a/app/models/algorithm_teacher_clue_calculation.rb
+++ b/app/models/algorithm_teacher_clue_calculation.rb
@@ -3,7 +3,7 @@ class AlgorithmTeacherClueCalculation < ApplicationRecord
                                         foreign_key: :teacher_clue_calculation_uuid,
                                         inverse_of: :algorithm_teacher_clue_calculations
 
-  unique_index :teacher_clue_calculation_uuid, :algorithm_name
+  unique_index :teacher_clue_calculation_uuid, :algorithm_name, scoped_to: :teacher_clue_calculation
 
   validates :clue_data, presence: true
 

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -13,14 +13,16 @@ class ApplicationRecord < ActiveRecord::Base
     end
 
     # Deadlock-resistant update_all and delete_all
-    define_singleton_method :ordered_update_all do |*pargs, lock_sql: 'FOR NO KEY UPDATE', **kwargs|
+    define_singleton_method :ordered_update_all do |*pargs, lock_sql: nil, **kwargs|
+      lock_sql ||= "FOR NO KEY UPDATE OF #{table_name}"
       uuids = ordered.lock(lock_sql).pluck(:uuid)
       next 0 if uuids.empty?
 
       args = kwargs.empty? ? pargs : pargs + [kwargs]
       unscoped.where(uuid: uuids).update_all(*args)
     end
-    define_singleton_method :ordered_delete_all do |*pargs, lock_sql: 'FOR UPDATE', **kwargs|
+    define_singleton_method :ordered_delete_all do |*pargs, lock_sql: nil, **kwargs|
+      lock_sql ||= "FOR UPDATE OF #{table_name}"
       uuids = ordered.lock(lock_sql).pluck(:uuid)
       next 0 if uuids.empty?
 

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -3,13 +3,47 @@ class ApplicationRecord < ActiveRecord::Base
 
   validates :uuid, presence: true, uniqueness: true
 
+  def self.recursive_hash_to_array(hash)
+    hash.respond_to?(:map) ? hash.map { |val| recursive_hash_to_array(val) } : hash
+  end
+
   # The columns listed here should make up a unique index that exists on the record's table
-  def self.unique_index(*columns)
+  def self.unique_index(*columns, scoped_to: nil)
     raise ArgumentError if columns.size == 0
 
-    scope :ordered, -> { order(*columns) }
+    class_attribute :order_columns
+    self.order_columns = columns
+
+    scope_reflection = reflect_on_association(scoped_to) unless scoped_to.nil?
+
+    scope :ordered, -> do
+      rel = all
+
+      if scope_reflection
+        joins = recursive_hash_to_array(rel.joins_values).flatten
+        rel = rel.left_outer_joins(scoped_to) unless joins.include?(scoped_to.to_sym)
+
+        scoped_to_table_name = scope_reflection.table_name.to_sym
+        scope_columns = scope_reflection.klass.order_columns.map do |column|
+          "\"#{scoped_to_table_name}\".\"#{column}\""
+        end
+        rel = rel.order(*scope_columns)
+      end
+
+      rel.order(*order_columns)
+    end
     define_singleton_method :sort_proc do
-      ->(model) { columns.map { |column| model.public_send column } }
+      ->(model) do
+        scope_order = []
+
+        if scope_reflection
+          scope = model.public_send(scoped_to)
+
+          scope_order = scope.class.sort_proc.call(scope) unless scope.nil?
+        end
+
+        scope_order + order_columns.map { |column| model.public_send column }
+      end
     end
 
     # Deadlock-resistant update_all and delete_all
@@ -30,9 +64,9 @@ class ApplicationRecord < ActiveRecord::Base
       unscoped.where(uuid: uuids).delete_all(*args)
     end
 
-    last_column = columns.last
+    last_column = order_columns.last
 
-    other_columns = columns[0..-2]
+    other_columns = order_columns[0..-2]
     other_columns.each { |column| validates column, presence: true }
 
     return if last_column == :uuid

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -1,4 +1,9 @@
 class Course < ApplicationRecord
+  has_many :course_containers, primary_key: :uuid,
+                               foreign_key: :course_uuid,
+                               dependent: :destroy,
+                               inverse_of: :course
+
   has_many :students, primary_key: :uuid,
                       foreign_key: :course_uuid,
                       dependent: :destroy,

--- a/app/models/course_container.rb
+++ b/app/models/course_container.rb
@@ -1,5 +1,9 @@
 class CourseContainer < ApplicationRecord
-  unique_index :uuid
+  belongs_to :course, primary_key: :uuid,
+                      foreign_key: :course_uuid,
+                      inverse_of: :course_containers
+
+  unique_index :uuid, scoped_to: :course
 
   validates :course_uuid, presence: true
 end

--- a/spec/factories/course_containers.rb
+++ b/spec/factories/course_containers.rb
@@ -3,7 +3,7 @@ FactoryGirl.define do
     transient     { students_count { rand(10) } }
 
     uuid          { SecureRandom.uuid }
-    course_uuid   { SecureRandom.uuid }
+    course
     student_uuids { students_count.times.map { SecureRandom.uuid } }
   end
 end


### PR DESCRIPTION
Only lock records relevant for update/delete in ordered_update_all and ordered_delete_all.
Added scoped ordering so algorithm_xyx records sort the same and thus don't conflict with xyz records.