### PR TITLE
Speed up the last(?) slow query in biglearn-scheduler

### DIFF
--- a/app/domain/services/fetch_clue_calculations/service.rb
+++ b/app/domain/services/fetch_clue_calculations/service.rb
@@ -5,11 +5,11 @@ class Services::FetchClueCalculations::Service < Services::ApplicationService
     sanitized_algorithm_name = ActiveRecord::Base.sanitize(algorithm_name.downcase)
 
     student_clue_calculations = StudentClueCalculation
-      .where.not("\"algorithm_names\" && ARRAY[#{sanitized_algorithm_name}]::varchar[]")
+      .where.not("\"algorithm_names\" @> ARRAY[#{sanitized_algorithm_name}]::varchar[]")
       .take(BATCH_SIZE)
 
     teacher_clue_calculations = TeacherClueCalculation
-      .where.not("\"algorithm_names\" && ARRAY[#{sanitized_algorithm_name}]::varchar[]")
+      .where.not("\"algorithm_names\" @> ARRAY[#{sanitized_algorithm_name}]::varchar[]")
       .take(BATCH_SIZE)
 
     clue_calculations = student_clue_calculations + teacher_clue_calculations

--- a/app/domain/services/fetch_ecosystem_matrix_updates/service.rb
+++ b/app/domain/services/fetch_ecosystem_matrix_updates/service.rb
@@ -5,7 +5,7 @@ class Services::FetchEcosystemMatrixUpdates::Service < Services::ApplicationServ
     sanitized_algorithm_name = AlgorithmEcosystemMatrixUpdate.sanitize(algorithm_name.downcase)
 
     ecosystem_matrix_updates = EcosystemMatrixUpdate
-      .where.not("\"algorithm_names\" && ARRAY[#{sanitized_algorithm_name}]::varchar[]")
+      .where.not("\"algorithm_names\" @> ARRAY[#{sanitized_algorithm_name}]::varchar[]")
       .take(BATCH_SIZE)
 
     ecosystem_matrix_update_responses = ecosystem_matrix_updates.map do |ecosystem_matrix_update|

--- a/app/domain/services/fetch_exercise_calculations/service.rb
+++ b/app/domain/services/fetch_exercise_calculations/service.rb
@@ -6,7 +6,7 @@ class Services::FetchExerciseCalculations::Service < Services::ApplicationServic
 
     exercise_calculations = ExerciseCalculation
       .with_exercise_uuids
-      .where.not("\"algorithm_names\" && ARRAY[#{sanitized_algorithm_name}]::varchar[]")
+      .where.not("\"algorithm_names\" @> ARRAY[#{sanitized_algorithm_name}]::varchar[]")
       .take(BATCH_SIZE)
 
     exercise_calculation_responses = exercise_calculations.map do |exercise_calculation|

--- a/app/domain/services/prepare_clue_calculations/service.rb
+++ b/app/domain/services/prepare_clue_calculations/service.rb
@@ -366,8 +366,8 @@ class Services::PrepareClueCalculations::Service < Services::ApplicationService
           response_join_query = <<-JOIN_SQL.strip_heredoc
             INNER JOIN (#{ValuesTable.new(response_values_array)})
               AS "values" ("student_uuids", "exercise_uuids")
-            ON "values"."student_uuids" @> ARRAY["responses"."student_uuid"]
-              AND "values"."exercise_uuids" @> ARRAY["responses"."exercise_uuid"]
+            ON "values"."student_uuids" && ARRAY["responses"."student_uuid"]
+              AND "values"."exercise_uuids" && ARRAY["responses"."exercise_uuid"]
           JOIN_SQL
           Response
             .joins(assigned_exercise: :assignment)

--- a/app/domain/services/update_clue_calculations/service.rb
+++ b/app/domain/services/update_clue_calculations/service.rb
@@ -113,7 +113,7 @@ class Services::UpdateClueCalculations::Service < Services::ApplicationService
         AlgorithmExerciseCalculation
           .joins(:exercise_calculation)
           .joins(algorithm_exercise_calculation_join_query)
-          .ordered_update_all(is_uploaded_for_student: false)
+          .ordered_update_all(is_pending_for_student: true)
       end
 
       { clue_calculation_update_responses: clue_calculation_update_responses }

--- a/app/domain/services/update_student_history/service.rb
+++ b/app/domain/services/update_student_history/service.rb
@@ -121,6 +121,7 @@ class Services::UpdateStudentHistory::Service < Services::ApplicationService
         due_assignments_size
       end
 
+      # If we got less assignments than the batch size, then this is the last batch
       total_due_assignments += num_due_assignments
       break if num_due_assignments < BATCH_SIZE
     end

--- a/app/domain/services/upload_assignment_exercises/service.rb
+++ b/app/domain/services/upload_assignment_exercises/service.rb
@@ -28,21 +28,8 @@ class Services::UploadAssignmentExercises::Service < Services::ApplicationServic
         # Find algorithm_exercise_calculations with assignments that need PEs or SPEs
         # No order needed because of SKIP LOCKED
         algorithm_exercise_calculations = AlgorithmExerciseCalculation
-          .joins(:exercise_calculation)
-          .where(
-            Assignment.need_pes_or_spes.where(
-              aa[:student_uuid].eq(ec[:student_uuid]).and(
-                aa[:ecosystem_uuid].eq(ec[:ecosystem_uuid])
-              )
-            )
-            .where.not(
-              <<-NOT_SQL.strip_heredoc
-                "algorithm_exercise_calculations"."is_uploaded_for_assignment_uuids" @>
-                ARRAY["assignments"."uuid"]::varchar[]
-              NOT_SQL
-            ).exists
-          )
-          .lock('FOR NO KEY UPDATE OF "algorithm_exercise_calculations" SKIP LOCKED')
+          .where('CARDINALITY("algorithm_exercise_calculations"."pending_assignment_uuids") > 0')
+          .lock('FOR NO KEY UPDATE SKIP LOCKED')
           .take(BATCH_SIZE)
         algorithm_exercise_calculations_size = algorithm_exercise_calculations.size
         next 0 if algorithm_exercise_calculations_size == 0
@@ -51,16 +38,10 @@ class Services::UploadAssignmentExercises::Service < Services::ApplicationServic
         algorithm_exercise_calculation_uuids = algorithm_exercise_calculations_by_uuid.keys
 
         assignments = Assignment
-          .need_pes_or_spes
           .select([ aa[Arel.star], aec[:uuid].as('algorithm_exercise_calculation_uuid') ])
           .joins(exercise_calculation: :algorithm_exercise_calculations)
+          .where(uuid: algorithm_exercise_calculations.flat_map(&:pending_assignment_uuids))
           .where(algorithm_exercise_calculations: { uuid: algorithm_exercise_calculation_uuids })
-          .where.not(
-            <<-NOT_SQL.strip_heredoc
-              "algorithm_exercise_calculations"."is_uploaded_for_assignment_uuids" @>
-              ARRAY["assignments"."uuid"]::varchar[]
-            NOT_SQL
-          )
 
         # Delete relevant AssignmentPe and AssignmentSpes, since we are about to reupload them
         pe_assignments = assignments.select(&:needs_pes?)
@@ -575,17 +556,16 @@ class Services::UploadAssignmentExercises::Service < Services::ApplicationServic
         end
 
         # Mark the AlgorithmExerciseCalculations as uploaded
-        assignments.each do |assignment|
-          algorithm_exercise_calculation =
-            algorithm_exercise_calculations_by_uuid[assignment.algorithm_exercise_calculation_uuid]
-          algorithm_exercise_calculation.is_uploaded_for_assignment_uuids =
-            algorithm_exercise_calculation.is_uploaded_for_assignment_uuids + [ assignment.uuid ]
+        assignments.group_by(&:algorithm_exercise_calculation_uuid).each do |calc_uuid, assignments|
+          algorithm_exercise_calculation = algorithm_exercise_calculations_by_uuid[calc_uuid]
+          algorithm_exercise_calculation.pending_assignment_uuids -= assignments.map(&:uuid)
         end
+
         # No sort needed because already locked above
         AlgorithmExerciseCalculation.import(
           algorithm_exercise_calculations_by_uuid.values,
           validate: false, on_duplicate_key_update: {
-            conflict_target: [ :uuid ], columns: [ :is_uploaded_for_assignment_uuids ]
+            conflict_target: [ :uuid ], columns: [ :pending_assignment_uuids ]
           }
         )
 

--- a/app/domain/services/upload_student_clue_calculations/service.rb
+++ b/app/domain/services/upload_student_clue_calculations/service.rb
@@ -20,6 +20,8 @@ class Services::UploadStudentClueCalculations::Service < Services::ApplicationSe
           .where(is_uploaded: false)
           .lock('FOR NO KEY UPDATE OF "algorithm_student_clue_calculations" SKIP LOCKED')
           .take(BATCH_SIZE)
+        algorithm_calculations_size = algorithm_calculations.size
+        next 0 if algorithm_calculations_size == 0
 
         student_clue_requests = algorithm_calculations.map do |algorithm_calculation|
           calculation = algorithm_calculation.student_clue_calculation
@@ -40,7 +42,7 @@ class Services::UploadStudentClueCalculations::Service < Services::ApplicationSe
         AlgorithmStudentClueCalculation.where(uuid: algorithm_calculation_uuids)
                                        .update_all(is_uploaded: true)
 
-        algorithm_calculations.size
+        algorithm_calculations_size
       end
 
       # If we got less calculations than the batch size, then this is the last batch

--- a/app/domain/services/upload_student_exercises/service.rb
+++ b/app/domain/services/upload_student_exercises/service.rb
@@ -22,7 +22,7 @@ class Services::UploadStudentExercises::Service < Services::ApplicationService
         # No order needed because of SKIP LOCKED
         algorithm_exercise_calculations = AlgorithmExerciseCalculation
           .select([:uuid, :algorithm_name, :exercise_uuids])
-          .where(is_uploaded_for_student: false)
+          .where(is_pending_for_student: true)
           .lock('FOR NO KEY UPDATE SKIP LOCKED')
           .take(BATCH_SIZE)
         algorithm_exercise_calculations_size = algorithm_exercise_calculations.size
@@ -228,7 +228,7 @@ class Services::UploadStudentExercises::Service < Services::ApplicationService
         # Mark the AlgorithmExerciseCalculations as uploaded
         # No order needed because already locked above
         AlgorithmExerciseCalculation.where(uuid: algorithm_exercise_calculation_uuids)
-                                    .update_all(is_uploaded_for_student: true)
+                                    .update_all(is_pending_for_student: false)
 
         algorithm_exercise_calculations_size
       end

--- a/app/domain/services/upload_teacher_clue_calculations/service.rb
+++ b/app/domain/services/upload_teacher_clue_calculations/service.rb
@@ -20,6 +20,8 @@ class Services::UploadTeacherClueCalculations::Service < Services::ApplicationSe
           .where(is_uploaded: false)
           .lock('FOR NO KEY UPDATE OF "algorithm_teacher_clue_calculations" SKIP LOCKED')
           .take(BATCH_SIZE)
+        algorithm_calculations_size = algorithm_calculations.size
+        next 0 if algorithm_calculations_size == 0
 
         teacher_clue_requests = algorithm_calculations.map do |algorithm_calculation|
           calculation = algorithm_calculation.teacher_clue_calculation
@@ -40,7 +42,7 @@ class Services::UploadTeacherClueCalculations::Service < Services::ApplicationSe
         AlgorithmTeacherClueCalculation.where(uuid: algorithm_calculation_uuids)
                                        .update_all(is_uploaded: true)
 
-        algorithm_calculations.size
+        algorithm_calculations_size
       end
 
       # If we got less calculations than the batch size, then this is the last batch

--- a/app/models/ecosystem_exercise.rb
+++ b/app/models/ecosystem_exercise.rb
@@ -20,7 +20,7 @@ class EcosystemExercise < ApplicationRecord
     -> do
       where(
         <<-WHERE_SQL.strip_heredoc
-          "student_clue_calculations"."exercise_uuids" @>
+          "student_clue_calculations"."exercise_uuids" &&
           ARRAY["ecosystem_exercises"."exercise_uuid"]::varchar[]
         WHERE_SQL
       )
@@ -32,7 +32,7 @@ class EcosystemExercise < ApplicationRecord
     sanitized_exercise_uuid = self.class.sanitize exercise_uuid
     StudentClueCalculation.where(ecosystem_uuid: ecosystem_uuid).where(
       <<-WHERE_SQL.strip_heredoc
-        "student_clue_calculations"."exercise_uuids" @> ARRAY[#{sanitized_exercise_uuid}]::varchar[]
+        "student_clue_calculations"."exercise_uuids" && ARRAY[#{sanitized_exercise_uuid}]::varchar[]
       WHERE_SQL
     )
   end
@@ -41,7 +41,7 @@ class EcosystemExercise < ApplicationRecord
     -> do
       where(
         <<-WHERE_SQL.strip_heredoc
-          "teacher_clue_calculations"."exercise_uuids" @>
+          "teacher_clue_calculations"."exercise_uuids" &&
           ARRAY["ecosystem_exercises"."exercise_uuid"]::varchar[]
         WHERE_SQL
       )
@@ -53,7 +53,7 @@ class EcosystemExercise < ApplicationRecord
     sanitized_exercise_uuid = self.class.sanitize exercise_uuid
     TeacherClueCalculation.where(ecosystem_uuid: ecosystem_uuid).where(
       <<-WHERE_SQL.strip_heredoc
-        "teacher_clue_calculations"."exercise_uuids" @> ARRAY[#{sanitized_exercise_uuid}]::varchar[]
+        "teacher_clue_calculations"."exercise_uuids" && ARRAY[#{sanitized_exercise_uuid}]::varchar[]
       WHERE_SQL
     )
   end

--- a/app/models/student_clue_calculation.rb
+++ b/app/models/student_clue_calculation.rb
@@ -12,7 +12,7 @@ class StudentClueCalculation < ApplicationRecord
     -> do
       where(
         <<-WHERE_SQL.strip_heredoc
-          "student_clue_calculations"."exercise_uuids" @>
+          "student_clue_calculations"."exercise_uuids" &&
           ARRAY["ecosystem_exercises"."exercise_uuid"]
         WHERE_SQL
       )

--- a/app/models/teacher_clue_calculation.rb
+++ b/app/models/teacher_clue_calculation.rb
@@ -12,7 +12,7 @@ class TeacherClueCalculation < ApplicationRecord
     -> do
       where(
         <<-WHERE_SQL.strip_heredoc
-          "teacher_clue_calculations"."exercise_uuids" @>
+          "teacher_clue_calculations"."exercise_uuids" &&
           ARRAY["ecosystem_exercises"."exercise_uuid"]
         WHERE_SQL
       )

--- a/db/migrate/20181116223917_change_is_uploaded_to_pending.rb
+++ b/db/migrate/20181116223917_change_is_uploaded_to_pending.rb
@@ -1,0 +1,66 @@
+class ChangeIsUploadedToPending < ActiveRecord::Migration[5.0]
+  def up
+    add_column :algorithm_exercise_calculations, :is_pending_for_student, :boolean,
+               null: false, default: true
+    add_column :algorithm_exercise_calculations, :pending_assignment_uuids, :string, array: true
+
+    AlgorithmExerciseCalculation.update_all(
+      <<-UPDATE_SQL.strip_heredoc
+        "is_pending_for_student" = NOT "is_uploaded_for_student",
+        "pending_assignment_uuids" = ARRAY(
+          SELECT "assignments"."uuid"::varchar
+          FROM "assignments"
+          INNER JOIN "exercise_calculations"
+            ON "exercise_calculations"."student_uuid" = "assignments"."student_uuid"
+            AND "exercise_calculations"."ecosystem_uuid" = "assignments"."ecosystem_uuid"
+          WHERE "exercise_calculations"."uuid" =
+            "algorithm_exercise_calculations"."exercise_calculation_uuid"
+          EXCEPT
+          SELECT UNNEST("is_uploaded_for_assignment_uuids")
+        )
+      UPDATE_SQL
+    )
+
+    add_index :algorithm_exercise_calculations, :is_pending_for_student
+    add_index :algorithm_exercise_calculations, 'CARDINALITY("pending_assignment_uuids")',
+              name: 'index_alg_ex_calc_on_cardinality_of_pending_assignment_uuids'
+
+    change_column_null :algorithm_exercise_calculations, :pending_assignment_uuids, false
+
+    remove_column :algorithm_exercise_calculations, :is_uploaded_for_student
+    remove_column :algorithm_exercise_calculations, :is_uploaded_for_assignment_uuids
+  end
+
+  def down
+    add_column :algorithm_exercise_calculations, :is_uploaded_for_student, :boolean
+    add_column :algorithm_exercise_calculations, :is_uploaded_for_assignment_uuids, :string,
+               array: true, null: false, default: []
+
+    AlgorithmExerciseCalculation.update_all(
+      <<-UPDATE_SQL.strip_heredoc
+        "is_uploaded_for_student" = NOT "is_pending_for_student",
+        "is_uploaded_for_assignment_uuids" = ARRAY(
+          SELECT "assignments"."uuid"::varchar
+          FROM "assignments"
+          INNER JOIN "exercise_calculations"
+            ON "exercise_calculations"."student_uuid" = "assignments"."student_uuid"
+            AND "exercise_calculations"."ecosystem_uuid" = "assignments"."ecosystem_uuid"
+          WHERE "exercise_calculations"."uuid" =
+            "algorithm_exercise_calculations"."exercise_calculation_uuid"
+          EXCEPT
+          SELECT UNNEST("pending_assignment_uuids")
+        )
+      UPDATE_SQL
+    )
+
+    add_index :algorithm_exercise_calculations, :is_uploaded_for_student,
+              name: 'index_alg_ex_calc_on_is_uploaded_for_student'
+    add_index :algorithm_exercise_calculations, :is_uploaded_for_assignment_uuids, using: :gin,
+              name: 'index_alg_ex_calc_on_is_uploaded_for_assignment_uuids'
+
+    change_column_null :algorithm_exercise_calculations, :is_uploaded_for_student, false
+
+    remove_column :algorithm_exercise_calculations, :is_pending_for_student
+    remove_column :algorithm_exercise_calculations, :pending_assignment_uuids
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20181112212315) do
+ActiveRecord::Schema.define(version: 20181116223917) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -27,17 +27,17 @@ ActiveRecord::Schema.define(version: 20181112212315) do
   end
 
   create_table "algorithm_exercise_calculations", force: :cascade do |t|
-    t.uuid     "uuid",                                          null: false
-    t.uuid     "exercise_calculation_uuid",                     null: false
-    t.citext   "algorithm_name",                                null: false
-    t.uuid     "exercise_uuids",                                null: false, array: true
-    t.datetime "created_at",                                    null: false
-    t.datetime "updated_at",                                    null: false
-    t.boolean  "is_uploaded_for_student",                       null: false
-    t.string   "is_uploaded_for_assignment_uuids", default: [], null: false, array: true
+    t.uuid     "uuid",                                     null: false
+    t.uuid     "exercise_calculation_uuid",                null: false
+    t.citext   "algorithm_name",                           null: false
+    t.uuid     "exercise_uuids",                           null: false, array: true
+    t.datetime "created_at",                               null: false
+    t.datetime "updated_at",                               null: false
+    t.boolean  "is_pending_for_student",    default: true, null: false
+    t.string   "pending_assignment_uuids",                 null: false, array: true
+    t.index "cardinality(pending_assignment_uuids)", name: "index_alg_ex_calc_on_cardinality_of_pending_assignment_uuids", using: :btree
     t.index ["exercise_calculation_uuid", "algorithm_name"], name: "index_alg_ex_calc_on_ex_calc_uuid_and_alg_name", unique: true, using: :btree
-    t.index ["is_uploaded_for_assignment_uuids"], name: "index_alg_ex_calc_on_is_uploaded_for_assignment_uuids", using: :gin
-    t.index ["is_uploaded_for_student"], name: "index_alg_ex_calc_on_is_uploaded_for_student", using: :btree
+    t.index ["is_pending_for_student"], name: "index_algorithm_exercise_calculations_on_is_pending_for_student", using: :btree
     t.index ["uuid"], name: "index_algorithm_exercise_calculations_on_uuid", unique: true, using: :btree
   end
 

--- a/spec/domain/services/fetch_course_events/service_spec.rb
+++ b/spec/domain/services/fetch_course_events/service_spec.rb
@@ -465,8 +465,8 @@ RSpec.describe Services::FetchCourseEvents::Service, type: :service do
         let(:algorithm_exercise_calculation) do
           FactoryGirl.create :algorithm_exercise_calculation,
             exercise_calculation: exercise_calculation,
-            is_uploaded_for_student: true,
-            is_uploaded_for_assignment_uuids: [ existing_assignment.uuid ]
+            is_pending_for_student: false,
+            pending_assignment_uuids: []
         end
         let!(:existing_assignment_pes)       do
           assigned_exercise_uuids.map do |assigned_exercise_uuid|
@@ -526,8 +526,8 @@ RSpec.describe Services::FetchCourseEvents::Service, type: :service do
           expect(assignment.pes_are_assigned).to eq pes_are_assigned
 
           algorithm_exercise_calculation.reload
-          expect(algorithm_exercise_calculation.is_uploaded_for_student).to eq false
-          expect(algorithm_exercise_calculation.is_uploaded_for_assignment_uuids).to eq []
+          expect(algorithm_exercise_calculation.is_pending_for_student).to eq true
+          expect(algorithm_exercise_calculation.pending_assignment_uuids).to eq [ assignment.uuid ]
         end
       end
     end

--- a/spec/domain/services/update_student_history/service_spec.rb
+++ b/spec/domain/services/update_student_history/service_spec.rb
@@ -420,7 +420,7 @@ RSpec.describe Services::UpdateStudentHistory::Service, type: :service do
 
       @aec_1 = FactoryGirl.create :algorithm_exercise_calculation,
                                   exercise_calculation: @exercise_calculation_1,
-                                  is_uploaded_for_assignment_uuids: [ @reading_1.uuid ]
+                                  pending_assignment_uuids: [ @homework_1.uuid ]
       @aec_2 = FactoryGirl.create :algorithm_exercise_calculation,
                                   exercise_calculation: @exercise_calculation_2
     end
@@ -467,8 +467,8 @@ RSpec.describe Services::UpdateStudentHistory::Service, type: :service do
       it 'adds the assignments to the student history in the correct order' do
         expect { subject.process }.to  not_change { Assignment.count }
                                   .and not_change { AssignmentSpe.count  }
-                                  .and     change { @aec_1.reload.is_uploaded_for_assignment_uuids }
-                                  .and not_change { @aec_2.reload.is_uploaded_for_assignment_uuids }
+                                  .and     change { Set.new @aec_1.reload.pending_assignment_uuids }
+                                  .and not_change { Set.new @aec_2.reload.pending_assignment_uuids }
 
         student_history_assignments = Assignment
           .where(uuid: all_assignment_uuids)
@@ -495,8 +495,8 @@ RSpec.describe Services::UpdateStudentHistory::Service, type: :service do
       it 'adds the assignments to the student history in the correct order' do
         expect { subject.process }.to  not_change { Assignment.count }
                                   .and not_change { AssignmentSpe.count  }
-                                  .and     change { @aec_1.reload.is_uploaded_for_assignment_uuids }
-                                  .and not_change { @aec_2.reload.is_uploaded_for_assignment_uuids }
+                                  .and     change { Set.new @aec_1.reload.pending_assignment_uuids }
+                                  .and not_change { Set.new @aec_2.reload.pending_assignment_uuids }
 
         student_history_assignments = Assignment
           .where(uuid: all_assignment_uuids)
@@ -523,8 +523,8 @@ RSpec.describe Services::UpdateStudentHistory::Service, type: :service do
       it 'adds the assignments to the student history in the correct order' do
         expect { subject.process }.to  not_change { Assignment.count }
                                   .and not_change { AssignmentSpe.count  }
-                                  .and     change { @aec_1.reload.is_uploaded_for_assignment_uuids }
-                                  .and not_change { @aec_2.reload.is_uploaded_for_assignment_uuids }
+                                  .and     change { Set.new @aec_1.reload.pending_assignment_uuids }
+                                  .and not_change { Set.new @aec_2.reload.pending_assignment_uuids }
 
         student_history_assignments = Assignment
           .where(uuid: all_assignment_uuids)
@@ -559,8 +559,8 @@ RSpec.describe Services::UpdateStudentHistory::Service, type: :service do
       it 'adds the assignments to the student history in the correct order' do
         expect { subject.process }.to  not_change { Assignment.count }
                                   .and not_change { AssignmentSpe.count  }
-                                  .and     change { @aec_1.reload.is_uploaded_for_assignment_uuids }
-                                  .and not_change { @aec_2.reload.is_uploaded_for_assignment_uuids }
+                                  .and     change { Set.new @aec_1.reload.pending_assignment_uuids }
+                                  .and not_change { Set.new @aec_2.reload.pending_assignment_uuids }
 
         student_history_assignments = Assignment
           .where(uuid: all_assignment_uuids)

--- a/spec/domain/services/upload_student_exercises/service_spec.rb
+++ b/spec/domain/services/upload_student_exercises/service_spec.rb
@@ -343,14 +343,14 @@ RSpec.describe Services::UploadStudentExercises::Service, type: :service do
         exercise_calculation: exercise_calculation_1,
         algorithm_name: 'local_query',
         exercise_uuids: old_exercise_uuids.shuffle,
-        is_uploaded_for_student: false
+        is_pending_for_student: true
       )
       @algorithm_exercise_calculation_2 = FactoryGirl.create(
         :algorithm_exercise_calculation,
         exercise_calculation: exercise_calculation_1,
         algorithm_name: 'tesr',
         exercise_uuids: old_exercise_uuids.shuffle,
-        is_uploaded_for_student: false
+        is_pending_for_student: true
       )
 
       exercise_calculation_2 = FactoryGirl.create(
@@ -363,14 +363,14 @@ RSpec.describe Services::UploadStudentExercises::Service, type: :service do
         exercise_calculation: exercise_calculation_2,
         algorithm_name: 'local_query',
         exercise_uuids: new_exercise_uuids.shuffle,
-        is_uploaded_for_student: false
+        is_pending_for_student: true
       )
       @algorithm_exercise_calculation_4 = FactoryGirl.create(
         :algorithm_exercise_calculation,
         exercise_calculation: exercise_calculation_2,
         algorithm_name: 'tesr',
         exercise_uuids: new_exercise_uuids.shuffle,
-        is_uploaded_for_student: false
+        is_pending_for_student: true
       )
     end
 

--- a/spec/factories/algorithm_exercise_calculations.rb
+++ b/spec/factories/algorithm_exercise_calculations.rb
@@ -1,12 +1,16 @@
 FactoryGirl.define do
   factory :algorithm_exercise_calculation do
-    transient                        { num_exercise_uuids { rand(10) + 1 } }
+    transient              { num_exercise_uuids { rand(10) + 1 } }
 
-    uuid                             { SecureRandom.uuid }
+    uuid                   { SecureRandom.uuid }
     exercise_calculation
-    algorithm_name                   { [ 'local_query', 'tesr' ].sample }
-    exercise_uuids                   { num_exercise_uuids.times.map { SecureRandom.uuid } }
-    is_uploaded_for_assignment_uuids { [] }
-    is_uploaded_for_student          { [ true, false ].sample }
+    algorithm_name         { [ 'local_query', 'tesr' ].sample }
+    exercise_uuids         { num_exercise_uuids.times.map { SecureRandom.uuid } }
+    is_pending_for_student { [ true, false ].sample }
+
+    after(:build) do |algorithm_exercise_calculation|
+      algorithm_exercise_calculation.pending_assignment_uuids ||=
+        algorithm_exercise_calculation.exercise_calculation.assignments.map(&:uuid)
+    end
   end
 end


### PR DESCRIPTION
Maybe not the last slow query, but seems to be the last of the queries that run constantly, even when idle, that had bad performance.

Still have 1 query left to fix in biglearn-api (fetch_course_events).

- Added early returns to most services
- Improved the first query in upload_assignment_exercises