### PR TITLE
remove migration step to update course active dates

### DIFF
--- a/db/migrate/20181120021615_add_starts_at_and_ends_at_to_courses.rb
+++ b/db/migrate/20181120021615_add_starts_at_and_ends_at_to_courses.rb
@@ -2,16 +2,6 @@ class AddStartsAtAndEndsAtToCourses < ActiveRecord::Migration[5.0]
   def change
     add_column :courses, :starts_at, :datetime
     add_column :courses, :ends_at, :datetime
-
-    reversible do |dir|
-      dir.up do
-        Course.reset_column_information
-
-        Services::FetchCourseEvents::Service.process event_types: [ :update_course_active_dates ],
-                                                     restart: true
-      end
-    end
-
     add_index :courses, [ :ends_at, :starts_at ]
   end
 end


### PR DESCRIPTION
Rather than doing this in the migration, we'll run it by hand after
the migration process completes