### PR TITLE
Fix production

### DIFF
--- a/app/domain/services/prepare_clue_calculations/service.rb
+++ b/app/domain/services/prepare_clue_calculations/service.rb
@@ -368,8 +368,8 @@ class Services::PrepareClueCalculations::Service < Services::ApplicationService
           response_join_query = <<-JOIN_SQL.strip_heredoc
             INNER JOIN (#{ValuesTable.new(response_values_array)})
               AS "values" ("student_uuids", "exercise_uuids")
-            ON "values"."student_uuids"::uuid[] && ARRAY["responses"."student_uuid"]
-              AND "values"."exercise_uuids"::uuid[] && ARRAY["responses"."exercise_uuid"]
+            ON "responses"."student_uuid" = ANY("values"."student_uuids"::uuid[])
+            AND "responses"."exercise_uuid" = ANY("values"."exercise_uuids"::uuid[])
           JOIN_SQL
           Response
             .joins(assigned_exercise: :assignment)

--- a/lib/tasks/fetch_metadatas/fetch_course_metadata_events.rake
+++ b/lib/tasks/fetch_metadatas/fetch_course_metadata_events.rake
@@ -1,0 +1,33 @@
+namespace :fetch_metadatas do
+
+  ## This rake task was created to manually fix sequence gaps
+  # it does roughly the same thing as the service in
+  # app/domain/services/fetch_course_metadatas/service.rb
+  # but is invoked manually
+  desc "import :count course metadata events at :offset"
+  task :fetch_course_metadata_events, [:offset, :count] => [:environment] do |task, args|
+
+    response = OpenStax::Biglearn::Api.client.send(
+      :single_api_request,
+      url: :fetch_course_metadatas,
+      request: {
+        max_num_metadatas: args[:count] || 1,
+        metadata_sequence_number_offset: args[:offset]
+      })
+
+    courses = response[:course_responses].map do |course_hash|
+      Course.new uuid: course_hash.fetch(:uuid),
+                 ecosystem_uuid: course_hash.fetch(:initial_ecosystem_uuid),
+                 sequence_number: 0,
+                 metadata_sequence_number: course_hash.fetch(:metadata_sequence_number),
+                 course_excluded_exercise_uuids: [],
+                 course_excluded_exercise_group_uuids: [],
+                 global_excluded_exercise_uuids: [],
+                 global_excluded_exercise_group_uuids: []
+    end
+
+    Course.import(
+      courses, validate: false, on_duplicate_key_ignore: { conflict_target: [ :uuid ] }
+    )
+  end
+end

--- a/spec/cassettes/fetch_metadatas_fetch_course_metadata_events/imports.yml
+++ b/spec/cassettes/fetch_metadatas_fetch_course_metadata_events/imports.yml
@@ -1,0 +1,56 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://localhost:3000/fetch_course_metadatas
+    body:
+      encoding: UTF-8
+      string: '{"max_num_metadatas":1,"metadata_sequence_number_offset":4291}'
+    headers:
+      User-Agent:
+      - Faraday v0.11.0
+      Content-Type:
+      - application/json
+      Biglearn-Api-Token:
+      - 56c3d42cdd96f892ec5448efbe7bfd52a6ff2c874319e7b7297e1ae0dffc1db999cff1c5eb5d5d1ba4e4a16069f72a8bd961791df75d9dd97ff029325eb9fb98
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 09 Jan 2019 19:41:21 GMT
+      Etag:
+      - W/"a95573c592d8018ac23442a2b91c5331"
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Request-Id:
+      - badf8865-8669-4ae3-8d3b-12fe1cf4bc92
+      X-Runtime:
+      - '0.003647'
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Length:
+      - '166'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"course_responses":[{"uuid":"b04d127c-df09-4ece-bd5a-46120603be09","initial_ecosystem_uuid":"96a193d0-f216-446e-92ef-1c1ecdfedc32","metadata_sequence_number":4291}]}'
+    http_version:
+  recorded_at: Wed, 09 Jan 2019 19:41:21 GMT
+recorded_with: VCR 3.0.3

--- a/spec/lib/tasks/fetch_metadatas/fetch_course_metadata_events_spec.rb
+++ b/spec/lib/tasks/fetch_metadatas/fetch_course_metadata_events_spec.rb
@@ -1,0 +1,15 @@
+require 'vcr_helper'
+require 'rake_helper'
+
+RSpec.describe 'fetch_metadatas:fetch_course_metadata_events', type: :task, vcr: VCR_OPTS do
+  include_context 'rake'
+
+  before(:each) { OpenStax::Biglearn::Api.use_real_client }
+  after(:each) { OpenStax::Biglearn::Api.use_fake_client }
+
+  it 'imports' do
+    expect {
+      subject.invoke(4291, 1)
+    }.to change { Course.count }.by 1
+  end
+end


### PR DESCRIPTION
Add rake task to import course metadata to fix bug where a few courses were missing ecosystem uuids.

Speeds up the query to find responses that need CLUE calculations