### PR TITLE
prevent logging large query parameters

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -82,6 +82,15 @@ Rails.application.configure do
     config.logger = ActiveSupport::TaggedLogging.new(logger)
   end
 
+  # do not log these huge params in order to prevent wasting disk space
+  config.filter_parameters += [
+    :exercise_calculation_updates,
+    :student_clue_requests,
+    :student_clue_updates,
+    :teacher_clue_updates,
+    :spe_updates,
+    :pe_updates
+  ]
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
 end


### PR DESCRIPTION
These are the largest culprits, found by running:
```
cat log/production.log |  awk '{ print length, $0 }' | sort -r -n -s | cut -d" " -f2- > /tmp/lines
```

