### PR TITLE
Speed up biglearn-scheduler

### DIFF
--- a/app/domain/services/ecosystem_matrices_updated/service.rb
+++ b/app/domain/services/ecosystem_matrices_updated/service.rb
@@ -6,7 +6,7 @@ class Services::EcosystemMatricesUpdated::Service < Services::ApplicationService
         .select(:uuid, :ecosystem_uuid, :algorithm_names)
         .where(uuid: relevant_update_uuids)
         .ordered
-        .lock('FOR NO KEY UPDATE')
+        .lock('FOR NO KEY UPDATE SKIP LOCKED')
         .index_by(&:uuid)
 
       algorithm_ecosystem_matrix_updates = []

--- a/app/domain/services/fetch_clue_calculations/service.rb
+++ b/app/domain/services/fetch_clue_calculations/service.rb
@@ -7,11 +7,13 @@ class Services::FetchClueCalculations::Service < Services::ApplicationService
     student_clue_calculations = StudentClueCalculation
       .where.not("\"algorithm_names\" @> ARRAY[#{sanitized_algorithm_name}]::varchar[]")
       .random_ordered
+      .lock('FOR SHARE SKIP LOCKED')
       .take(BATCH_SIZE)
 
     teacher_clue_calculations = TeacherClueCalculation
       .where.not("\"algorithm_names\" @> ARRAY[#{sanitized_algorithm_name}]::varchar[]")
       .random_ordered
+      .lock('FOR SHARE SKIP LOCKED')
       .take(BATCH_SIZE)
 
     clue_calculations = student_clue_calculations + teacher_clue_calculations

--- a/app/domain/services/fetch_ecosystem_matrix_updates/service.rb
+++ b/app/domain/services/fetch_ecosystem_matrix_updates/service.rb
@@ -7,6 +7,7 @@ class Services::FetchEcosystemMatrixUpdates::Service < Services::ApplicationServ
     ecosystem_matrix_updates = EcosystemMatrixUpdate
       .where.not("\"algorithm_names\" @> ARRAY[#{sanitized_algorithm_name}]::varchar[]")
       .random_ordered
+      .lock('FOR SHARE SKIP LOCKED')
       .take(BATCH_SIZE)
 
     ecosystem_matrix_update_responses = ecosystem_matrix_updates.map do |ecosystem_matrix_update|

--- a/app/domain/services/fetch_exercise_calculations/service.rb
+++ b/app/domain/services/fetch_exercise_calculations/service.rb
@@ -8,6 +8,7 @@ class Services::FetchExerciseCalculations::Service < Services::ApplicationServic
       .with_exercise_uuids
       .where.not("\"algorithm_names\" @> ARRAY[#{sanitized_algorithm_name}]::varchar[]")
       .random_ordered
+      .lock('FOR SHARE SKIP LOCKED')
       .take(BATCH_SIZE)
 
     exercise_calculation_responses = exercise_calculations.map do |exercise_calculation|

--- a/app/domain/services/update_clue_calculations/service.rb
+++ b/app/domain/services/update_clue_calculations/service.rb
@@ -7,13 +7,13 @@ class Services::UpdateClueCalculations::Service < Services::ApplicationService
         .select(:uuid, :student_uuid, :book_container_uuid, :algorithm_names)
         .where(uuid: relevant_calculation_uuids)
         .ordered
-        .lock('FOR NO KEY UPDATE')
+        .lock('FOR NO KEY UPDATE SKIP LOCKED')
         .index_by(&:uuid)
       teacher_clue_calculations_by_uuid = TeacherClueCalculation
         .select(:uuid, :course_container_uuid, :book_container_uuid, :algorithm_names)
         .where(uuid: relevant_calculation_uuids)
         .ordered
-        .lock('FOR NO KEY UPDATE')
+        .lock('FOR NO KEY UPDATE SKIP LOCKED')
         .index_by(&:uuid)
 
       algorithm_student_clue_calculations = []

--- a/app/domain/services/update_exercise_calculations/service.rb
+++ b/app/domain/services/update_exercise_calculations/service.rb
@@ -9,7 +9,7 @@ class Services::UpdateExerciseCalculations::Service < Services::ApplicationServi
         .select(:uuid, :student_uuid, :ecosystem_uuid, :algorithm_names)
         .where(uuid: calculation_uuids)
         .ordered
-        .lock('FOR NO KEY UPDATE')
+        .lock('FOR NO KEY UPDATE SKIP LOCKED')
         .index_by(&:uuid)
       exercise_calculation_uuids = exercise_calculations_by_uuid.keys
 


### PR DESCRIPTION
When fetching calculations to process or receiving update requests from algorithms, ignore records that are already locked.

Records that are locked have a good chance of changing, so the processed data will become useless. By ignoring them right away, we prevent the algorithms from becoming blocked waiting for the locks. This prevents a situation where there are calculations to process, but a few locked records are preventing the workers from doing anything.