### PR TITLE
Consume less memory when new assignments arrive

### DIFF
--- a/lib/values_table.rb
+++ b/lib/values_table.rb
@@ -11,10 +11,13 @@ class ValuesTable
     raise 'ValuesTable cannot be given an empty array' if values_array.empty?
     raise 'ValuesTable cannot be given an array containing empty arrays' \
       if values_array.any?(&:empty?)
+    # Ideally we wouldn't do this, but empty arrays in Postgres
+    # are hard to deal with and require typecasting
     raise 'ValuesTable must be given at least 1 valid row' \
       if values_array.all? { |values| values.any? { |value| value.is_a?(Array) && value.empty? } }
 
     "VALUES #{values_array.map do |values|
+      # See comment above
       next if values.any? { |value| value.is_a?(Array) && value.empty? }
 
       "(#{values.map { |value| sanitize value }.join(', ')})"


### PR DESCRIPTION
These lines: https://github.com/openstax/biglearn-scheduler/pull/96/files#diff-a05d0ddd23b0385e9aa82a72e4a691e3L682-L684 were loading the AlgorithmExerciseCalculations into memory and they are huge (especially the exercise_uuids column). Upsert requires loading all columns, so instead do an old-fashioned update which supports only loading certain columns to reduce the memory footprint.