### PR TITLE
Fix NotNullViolation when trying to calculate CLUes but records are missing

### DIFF
--- a/app/domain/services/fetch_course_events/service.rb
+++ b/app/domain/services/fetch_course_events/service.rb
@@ -578,7 +578,7 @@ class Services::FetchCourseEvents::Service < Services::ApplicationService
 
       # Find relevant ExerciseCalculations
       # The ExerciseCalculation lock ensures we don't miss updates on
-      # concurrent Assignment and AlgorithmExerciseCalculation inserts
+      # concurrent AlgorithmExerciseCalculation inserts
       exercise_calculation_uuids = ExerciseCalculation.where(
         <<~WHERE_SQL
           "exercise_calculations"."uuid" IN (

--- a/app/domain/services/prepare_clue_calculations/service.rb
+++ b/app/domain/services/prepare_clue_calculations/service.rb
@@ -110,32 +110,27 @@ class Services::PrepareClueCalculations::Service < Services::ApplicationService
           .flat_map do |from_ecosystem_uuid, responses|
           from_eco_book_container_uuids_map = from_book_container_uuids_map[from_ecosystem_uuid]
 
-          responses.map do |response|
-            next if response.latest_ecosystem_uuid == from_ecosystem_uuid
-
+          responses.select { |response| response.latest_ecosystem_uuid != from_ecosystem_uuid }
+                   .map do |response|
             exercise_uuid = response.exercise_uuid
             from_book_container_uuids = from_eco_book_container_uuids_map[exercise_uuid]
 
             [ from_ecosystem_uuid, response.latest_ecosystem_uuid, from_book_container_uuids ]
-          end.compact
+          end
         end + sccs_by_ecosystem_uuid.flat_map do |from_ecosystem_uuid, sccs|
           from_eco_book_container_uuids_map =
             from_book_container_uuids_map[from_ecosystem_uuid]
 
-          sccs.map do |scc|
-            next if scc.latest_ecosystem_uuid == from_ecosystem_uuid
-
+          sccs.select { |scc| scc.latest_ecosystem_uuid != from_ecosystem_uuid }.map do |scc|
             [ from_ecosystem_uuid, scc.latest_ecosystem_uuid, [ scc.book_container_uuid ] ]
-          end.compact
+          end
         end + tccs_by_ecosystem_uuid.flat_map do |from_ecosystem_uuid, tccs|
           from_eco_book_container_uuids_map =
             from_book_container_uuids_map[from_ecosystem_uuid]
 
-          tccs.map do |tcc|
-            next if tcc.latest_ecosystem_uuid == from_ecosystem_uuid
-
+          tccs.select { |tcc| tcc.latest_ecosystem_uuid != from_ecosystem_uuid }.map do |tcc|
             [ from_ecosystem_uuid, tcc.latest_ecosystem_uuid, [ tcc.book_container_uuid ] ]
-          end.compact
+          end
         end
         unless forward_mapping_values_array.empty?
           forward_mapping_join_query = <<~JOIN_SQL

--- a/app/domain/services/prepare_clue_calculations/service.rb
+++ b/app/domain/services/prepare_clue_calculations/service.rb
@@ -5,6 +5,8 @@ class Services::PrepareClueCalculations::Service < Services::ApplicationService
     start_time = Time.current
     log(:debug) { "Started at #{start_time}" }
 
+    re = Response.arel_table
+    co = Course.arel_table
     scc = StudentClueCalculation.arel_table
     tcc = TeacherClueCalculation.arel_table
 
@@ -16,19 +18,25 @@ class Services::PrepareClueCalculations::Service < Services::ApplicationService
         # Get Responses that have not yet been used in CLUes
         # Responses with no AssignedExercise or Assignment are completely ignored
         # No order needed because of SKIP LOCKED
-        responses = Response.joins(assigned_exercise: :assignment)
-                            .where(is_used_in_clue_calculations: false)
-                            .lock('FOR NO KEY UPDATE OF "responses" SKIP LOCKED')
-                            .take(BATCH_SIZE)
+        responses = Response
+          .select(re[Arel.star], co[:ecosystem_uuid].as('latest_ecosystem_uuid'))
+          .joins(student: :course, assigned_exercise: :assignment)
+          .where(is_used_in_clue_calculations: false)
+          .lock('FOR NO KEY UPDATE OF "responses" SKIP LOCKED')
+          .take(BATCH_SIZE)
         # Get any ClueCalculations that need to be recalculated
         # No order needed because of SKIP LOCKED
         sccs = StudentClueCalculation
+          .select(scc[Arel.star], co[:ecosystem_uuid].as('latest_ecosystem_uuid'))
+          .joins(student: :course)
           .where(scc[:recalculate_at].lteq(start_time))
-          .lock('FOR UPDATE SKIP LOCKED')
+          .lock('FOR UPDATE OF "student_clue_calculations" SKIP LOCKED')
           .take(BATCH_SIZE)
         tccs = TeacherClueCalculation
+          .select(tcc[Arel.star], co[:ecosystem_uuid].as('latest_ecosystem_uuid'))
+          .joins(course_container: :course)
           .where(tcc[:recalculate_at].lteq(start_time))
-          .lock('FOR UPDATE SKIP LOCKED')
+          .lock('FOR UPDATE OF "teacher_clue_calculations" SKIP LOCKED')
           .take(BATCH_SIZE)
         next [ 0, 0, 0 ] if responses.empty? && sccs.empty? && tccs.empty?
 
@@ -40,13 +48,10 @@ class Services::PrepareClueCalculations::Service < Services::ApplicationService
         sccs_by_ecosystem_uuid = sccs.group_by(&:ecosystem_uuid)
         tccs_by_ecosystem_uuid = tccs.group_by(&:ecosystem_uuid)
 
-        # Map the students to courses and course containers (for student CLUes)
-        course_uuid_by_student_uuid = {}
+        # Map the students to course containers (for student CLUes)
         course_container_uuids_by_student_uuids = {}
         Student.where(uuid: student_uuids).each do |student|
-          uuid = student.uuid
-          course_uuid_by_student_uuid[uuid] = student.course_uuid
-          course_container_uuids_by_student_uuids[uuid] = student.course_container_uuids
+          course_container_uuids_by_student_uuids[student.uuid] = student.course_container_uuids
         end
 
         # Map the course containers back to students (for teacher CLUes)
@@ -96,12 +101,6 @@ class Services::PrepareClueCalculations::Service < Services::ApplicationService
           end
         end
 
-        # Map the courses to latest ecosystems
-        course_uuids = course_uuid_by_course_container_uuid.values
-        latest_ecosystem_uuid_by_course_uuid = Course.where(uuid: course_uuids)
-                                                     .pluck(:uuid, :ecosystem_uuid)
-                                                     .to_h
-
         # Create queries to map the book_container_uuids to
         # book_container_uuids in the courses' latest ecosystems
         forward_mappings = Hash.new do |hash, key|
@@ -112,37 +111,30 @@ class Services::PrepareClueCalculations::Service < Services::ApplicationService
           from_eco_book_container_uuids_map = from_book_container_uuids_map[from_ecosystem_uuid]
 
           responses.map do |response|
-            student_uuid = response.student_uuid
-            course_uuid = course_uuid_by_student_uuid[student_uuid]
-            to_ecosystem_uuid = latest_ecosystem_uuid_by_course_uuid[course_uuid]
-            next if to_ecosystem_uuid.nil? || to_ecosystem_uuid == from_ecosystem_uuid
+            next if response.latest_ecosystem_uuid == from_ecosystem_uuid
 
             exercise_uuid = response.exercise_uuid
             from_book_container_uuids = from_eco_book_container_uuids_map[exercise_uuid]
 
-            [ from_ecosystem_uuid, to_ecosystem_uuid, from_book_container_uuids ]
+            [ from_ecosystem_uuid, response.latest_ecosystem_uuid, from_book_container_uuids ]
           end.compact
         end + sccs_by_ecosystem_uuid.flat_map do |from_ecosystem_uuid, sccs|
           from_eco_book_container_uuids_map =
             from_book_container_uuids_map[from_ecosystem_uuid]
 
           sccs.map do |scc|
-            course_uuid = course_uuid_by_student_uuid[scc.student_uuid]
-            to_ecosystem_uuid = latest_ecosystem_uuid_by_course_uuid[course_uuid]
-            next if to_ecosystem_uuid.nil? || to_ecosystem_uuid == from_ecosystem_uuid
+            next if scc.latest_ecosystem_uuid == from_ecosystem_uuid
 
-            [ from_ecosystem_uuid, to_ecosystem_uuid, [ scc.book_container_uuid ] ]
+            [ from_ecosystem_uuid, scc.latest_ecosystem_uuid, [ scc.book_container_uuid ] ]
           end.compact
         end + tccs_by_ecosystem_uuid.flat_map do |from_ecosystem_uuid, tccs|
           from_eco_book_container_uuids_map =
             from_book_container_uuids_map[from_ecosystem_uuid]
 
           tccs.map do |tcc|
-            course_uuid = course_uuid_by_course_container_uuid[tcc.course_container_uuid]
-            to_ecosystem_uuid = latest_ecosystem_uuid_by_course_uuid[course_uuid]
-            next if to_ecosystem_uuid.nil? || to_ecosystem_uuid == from_ecosystem_uuid
+            next if tcc.latest_ecosystem_uuid == from_ecosystem_uuid
 
-            [ from_ecosystem_uuid, to_ecosystem_uuid, [ tcc.book_container_uuid ] ]
+            [ from_ecosystem_uuid, tcc.latest_ecosystem_uuid, [ tcc.book_container_uuid ] ]
           end.compact
         end
         unless forward_mapping_values_array.empty?
@@ -198,8 +190,7 @@ class Services::PrepareClueCalculations::Service < Services::ApplicationService
 
             # Find which is the response's book_container_uuid
             # and which ecosystem it must map to
-            course_uuid = course_uuid_by_student_uuid[student_uuid]
-            to_ecosystem_uuid = latest_ecosystem_uuid_by_course_uuid[course_uuid]
+            to_ecosystem_uuid = response.latest_ecosystem_uuid
             from_book_container_uuids =
               from_book_container_uuids_map[from_ecosystem_uuid][exercise_uuid]
 
@@ -228,8 +219,7 @@ class Services::PrepareClueCalculations::Service < Services::ApplicationService
           sccs.each do |scc|
             # Find the student's course and its latest ecosystem
             student_uuid = scc.student_uuid
-            course_uuid = course_uuid_by_student_uuid[student_uuid]
-            to_ecosystem_uuid = latest_ecosystem_uuid_by_course_uuid[course_uuid]
+            to_ecosystem_uuid = scc.latest_ecosystem_uuid
 
             # Forward map the from_book_container_uuid to find the to_book_container_uuid
             from_book_container_uuid = scc.book_container_uuid
@@ -247,8 +237,7 @@ class Services::PrepareClueCalculations::Service < Services::ApplicationService
           tccs.each do |tcc|
             # Find the course container's course and its latest ecosystem
             course_container_uuid = tcc.course_container_uuid
-            course_uuid = course_uuid_by_course_container_uuid[course_container_uuid]
-            to_ecosystem_uuid = latest_ecosystem_uuid_by_course_uuid[course_uuid]
+            to_ecosystem_uuid = tcc.latest_ecosystem_uuid
 
             # Forward map the from_book_container_uuid to find the to_book_container_uuid
             from_book_container_uuid = tcc.book_container_uuid

--- a/app/models/course_container.rb
+++ b/app/models/course_container.rb
@@ -1,9 +1,12 @@
 class CourseContainer < ApplicationRecord
+  has_many :teacher_clue_calculations, primary_key: :uuid,
+                                       foreign_key: :course_container_uuid,
+                                       dependent: :destroy,
+                                       inverse_of: :course_container
+
   belongs_to :course, primary_key: :uuid,
                       foreign_key: :course_uuid,
                       inverse_of: :course_containers
 
   unique_index :uuid
-
-  validates :course_uuid, presence: true
 end

--- a/app/models/student.rb
+++ b/app/models/student.rb
@@ -12,6 +12,11 @@ class Student < ApplicationRecord
                                    dependent: :destroy,
                                    inverse_of: :student
 
+  has_many :student_clue_calculations, primary_key: :uuid,
+                                       foreign_key: :student_uuid,
+                                       dependent: :destroy,
+                                       inverse_of: :student
+
   belongs_to :course, primary_key: :uuid,
                       foreign_key: :course_uuid,
                       inverse_of: :students

--- a/app/models/student_clue_calculation.rb
+++ b/app/models/student_clue_calculation.rb
@@ -28,11 +28,15 @@ class StudentClueCalculation < ApplicationRecord
     )
   end
 
+  belongs_to :student, primary_key: :uuid,
+                       foreign_key: :student_uuid,
+                       inverse_of: :student_clue_calculations
+
   unique_index :student_uuid, :book_container_uuid
 
   validates :ecosystem_uuid,      presence: true
   validates :book_container_uuid, presence: true
-  validates :student_uuid,        presence: true, uniqueness: { scope: :book_container_uuid }
+  validates :student_uuid,        uniqueness: { scope: :book_container_uuid }
   validates :exercise_uuids,      presence: true
   validates :responses,           presence: true
 

--- a/app/models/teacher_clue_calculation.rb
+++ b/app/models/teacher_clue_calculation.rb
@@ -28,6 +28,10 @@ class TeacherClueCalculation < ApplicationRecord
     )
   end
 
+  belongs_to :course_container, primary_key: :uuid,
+                                foreign_key: :course_container_uuid,
+                                inverse_of: :teacher_clue_calculations
+
   unique_index :course_container_uuid, :book_container_uuid
 
   validates :ecosystem_uuid,      presence: true

--- a/spec/factories/student_clue_calculations.rb
+++ b/spec/factories/student_clue_calculations.rb
@@ -6,9 +6,9 @@ FactoryBot.define do
     end
 
     uuid                { SecureRandom.uuid }
+    student
     ecosystem_uuid      { SecureRandom.uuid }
     book_container_uuid { SecureRandom.uuid }
-    student_uuid        { SecureRandom.uuid }
     exercise_uuids      { num_exercise_uuids.times.map { SecureRandom.uuid } }
     responses           do
       num_responses.times.map do

--- a/spec/factories/teacher_clue_calculations.rb
+++ b/spec/factories/teacher_clue_calculations.rb
@@ -7,9 +7,9 @@ FactoryBot.define do
     end
 
     uuid                  { SecureRandom.uuid }
+    course_container
     ecosystem_uuid        { SecureRandom.uuid }
     book_container_uuid   { SecureRandom.uuid }
-    course_container_uuid { SecureRandom.uuid }
     student_uuids         { num_student_uuids.times.map  { SecureRandom.uuid } }
     exercise_uuids        { num_exercise_uuids.times.map { SecureRandom.uuid } }
     responses             do

--- a/spec/models/course_container_spec.rb
+++ b/spec/models/course_container_spec.rb
@@ -3,5 +3,7 @@ require 'rails_helper'
 RSpec.describe CourseContainer, type: :model do
   subject { FactoryBot.create :course_container }
 
-  it { is_expected.to validate_presence_of :course_uuid }
+  it { is_expected.to belong_to :course }
+
+  it { is_expected.to have_many(:teacher_clue_calculations).dependent(:destroy) }
 end

--- a/spec/models/student_clue_calculation_spec.rb
+++ b/spec/models/student_clue_calculation_spec.rb
@@ -6,9 +6,10 @@ RSpec.describe StudentClueCalculation, type: :model do
   it { is_expected.to have_many(:algorithm_student_clue_calculations).dependent(:destroy) }
   it { is_expected.to have_many(:ecosystem_exercises) }
 
+  it { is_expected.to belong_to :student }
+
   it { is_expected.to validate_presence_of :ecosystem_uuid      }
   it { is_expected.to validate_presence_of :book_container_uuid }
-  it { is_expected.to validate_presence_of :student_uuid        }
   it { is_expected.to validate_presence_of :exercise_uuids      }
   it { is_expected.to validate_presence_of :responses           }
 

--- a/spec/models/student_spec.rb
+++ b/spec/models/student_spec.rb
@@ -9,6 +9,8 @@ RSpec.describe Student, type: :model do
 
   it { is_expected.to have_many(:exercise_calculations).dependent(:destroy) }
 
+  it { is_expected.to have_many(:student_clue_calculations).dependent(:destroy) }
+
   it { is_expected.to belong_to :course }
 
   it { is_expected.to validate_presence_of :course_container_uuids }

--- a/spec/models/teacher_clue_calculation_spec.rb
+++ b/spec/models/teacher_clue_calculation_spec.rb
@@ -6,6 +6,8 @@ RSpec.describe TeacherClueCalculation, type: :model do
   it { is_expected.to have_many(:algorithm_teacher_clue_calculations).dependent(:destroy) }
   it { is_expected.to have_many(:ecosystem_exercises) }
 
+  it { is_expected.to belong_to :course_container }
+
   it { is_expected.to validate_presence_of :ecosystem_uuid      }
   it { is_expected.to validate_presence_of :book_container_uuid }
   it { is_expected.to validate_presence_of :student_uuids       }


### PR DESCRIPTION
PrepareClueCalculations now joins the Course earlier so it will skip records where that link is missing.
Also simplifies some of the logic by loading the latest_ecosystem_uuid earlier.