### PR TITLE
Call anti-cheating code less often

### DIFF
--- a/app/domain/services/assignment_exercise_requests.rb
+++ b/app/domain/services/assignment_exercise_requests.rb
@@ -18,15 +18,16 @@ module Services::AssignmentExerciseRequests
       :course_excluded_exercise_group_uuids
     ).index_by(&:first)
 
-    # Get assignments that should have hidden feedback for each student
+    # Get assignments are not yet due or do not yet have feedback for each student
     student_uuids = assignments.map(&:student_uuid)
-    no_feedback_yet_assignments = Assignment
-                                    .where(student_uuid: student_uuids)
-                                    .where(Assignment.arel_table[:feedback_at].gt(current_time))
-                                    .pluck(:student_uuid, :assigned_exercise_uuids)
+    anti_cheating_assignments = Assignment
+                                  .where(student_uuid: student_uuids)
+                                  .where(aa[:due_at].gt(start_time))
+                                  .or(Assignment.where(aa[:feedback_at].gt(start_time)))
+                                  .pluck(:student_uuid, :assigned_exercise_uuids)
 
     # Convert excluded exercise uuids to group uuids
-    assigned_exercise_uuids = no_feedback_yet_assignments.flat_map(&:second)
+    assigned_exercise_uuids = anti_cheating_assignments.flat_map(&:second)
     assigned_exercise_group_uuid_by_uuid = Exercise.where(uuid: assigned_exercise_uuids)
                                                    .pluck(:uuid, :group_uuid)
                                                    .to_h
@@ -61,8 +62,8 @@ module Services::AssignmentExerciseRequests
         end
       end
 
-      # Add the exclusions from no_feedback_yet_assignments to the map above
-      no_feedback_yet_assignments.each do |student_uuid, assigned_exercise_uuids|
+      # Add the exclusions from anti_cheating_assignments to the map above
+      anti_cheating_assignments.each do |student_uuid, assigned_exercise_uuids|
         excluded_group_uuids =
           assigned_exercise_group_uuid_by_uuid.values_at(*assigned_exercise_uuids)
         excluded_exercise_uuids =

--- a/app/domain/services/assignment_exercise_requests.rb
+++ b/app/domain/services/assignment_exercise_requests.rb
@@ -20,10 +20,11 @@ module Services::AssignmentExerciseRequests
 
     # Get assignments are not yet due or do not yet have feedback for each student
     student_uuids = assignments.map(&:student_uuid)
+    aa = Assignment.arel_table
     anti_cheating_assignments = Assignment
+                                  .where(aa[:due_at].gt(current_time))
+                                  .or(Assignment.where(aa[:feedback_at].gt(current_time)))
                                   .where(student_uuid: student_uuids)
-                                  .where(aa[:due_at].gt(start_time))
-                                  .or(Assignment.where(aa[:feedback_at].gt(start_time)))
                                   .pluck(:student_uuid, :assigned_exercise_uuids)
 
     # Convert excluded exercise uuids to group uuids

--- a/app/domain/services/fetch_course_events/service.rb
+++ b/app/domain/services/fetch_course_events/service.rb
@@ -115,6 +115,7 @@ class Services::FetchCourseEvents::Service < Services::ApplicationService
     assignments_hash = {}
     used_algorithm_exercise_calculation_uuids = []
     assigned_exercises = []
+    anti_cheating_assigned_exercise_uuids = []
     student_uuids_by_assigned_exercise_uuid = Hash.new { |hash, key| hash[key] = [] }
     responses_hash = {}
     courses = course_event_responses.map do |course_event_response|
@@ -313,9 +314,9 @@ class Services::FetchCourseEvents::Service < Services::ApplicationService
         exercise_uuids = exercises.map { |exercise| exercise.fetch(:exercise_uuid) }.uniq
 
         exclusion_info = data.fetch(:exclusion_info, {})
-        opens_at = exclusion_info[:opens_at]
-        due_at = exclusion_info[:due_at]
-        feedback_at = exclusion_info[:feedback_at]
+        opens_at = DateTime.iso8601(exclusion_info[:opens_at]) rescue nil
+        due_at = DateTime.iso8601(exclusion_info[:due_at]) rescue nil
+        feedback_at = DateTime.iso8601(exclusion_info[:feedback_at]) rescue nil
 
         pe_calculation_uuid = data.dig(:pes, :calculation_uuid)
         spe_calculation_uuid = data.dig(:spes, :calculation_uuid)
@@ -331,9 +332,9 @@ class Services::FetchCourseEvents::Service < Services::ApplicationService
           ecosystem_uuid: ecosystem_uuid,
           student_uuid: student_uuid,
           assignment_type: data.fetch(:assignment_type),
-          opens_at: opens_at.nil? ? nil : DateTime.iso8601(opens_at),
-          due_at: due_at.nil? ? nil : DateTime.iso8601(due_at),
-          feedback_at: feedback_at.nil? ? nil : DateTime.iso8601(feedback_at),
+          opens_at: opens_at,
+          due_at: due_at,
+          feedback_at: feedback_at,
           assigned_book_container_uuids: data.fetch(:assigned_book_container_uuids),
           assigned_exercise_uuids: exercise_uuids,
           goal_num_tutor_assigned_spes: data[:goal_num_tutor_assigned_spes],
@@ -345,15 +346,20 @@ class Services::FetchCourseEvents::Service < Services::ApplicationService
         )
 
         data.fetch(:assigned_exercises).each do |assigned_exercise|
+          assigned_exercise_uuid = assigned_exercise.fetch(:trial_uuid)
           exercise_uuid = assigned_exercise.fetch(:exercise_uuid)
 
           assigned_exercises << AssignedExercise.new(
-            uuid: assigned_exercise.fetch(:trial_uuid),
+            uuid: assigned_exercise_uuid,
             assignment: assignments_hash[assignment_uuid],
             exercise_uuid: exercise_uuid,
             is_spe: assigned_exercise.fetch(:is_spe),
             is_pe: assigned_exercise.fetch(:is_pe)
           )
+
+          anti_cheating_assigned_exercise_uuids << assigned_exercise_uuid \
+            if (!due_at.nil? && due_at > start_time) ||
+               (!feedback_at.nil? && feedback_at > start_time)
         end
       end
 
@@ -551,7 +557,6 @@ class Services::FetchCourseEvents::Service < Services::ApplicationService
 
     unless assignments_hash.empty?
       assignment_uuids = assignments_hash.keys
-      assigned_exercise_uuids = assigned_exercises.map(&:uuid)
 
       # Find relevant ExerciseCalculations
       # The ExerciseCalculation lock ensures we don't miss updates on
@@ -575,7 +580,7 @@ class Services::FetchCourseEvents::Service < Services::ApplicationService
                   student: { assignments: :assigned_exercises }
                 )
                 .where('"assigned_exercises"."exercise_uuid" = "student_pes"."exercise_uuid"')
-                .where(assigned_exercises: { uuid: assigned_exercise_uuids })
+                .where(assigned_exercises: { uuid: anti_cheating_assigned_exercise_uuids })
                 .to_sql
             }
             UNION ALL
@@ -584,7 +589,7 @@ class Services::FetchCourseEvents::Service < Services::ApplicationService
                 .select(:uuid)
                 .joins(assignments: :assignment_pes, student: { assignments: :assigned_exercises })
                 .where('"assigned_exercises"."exercise_uuid" = "assignment_pes"."exercise_uuid"')
-                .where(assigned_exercises: { uuid: assigned_exercise_uuids })
+                .where(assigned_exercises: { uuid: anti_cheating_assigned_exercise_uuids })
                 .to_sql
             }
             UNION ALL
@@ -593,7 +598,7 @@ class Services::FetchCourseEvents::Service < Services::ApplicationService
                 .select(:uuid)
                 .joins(assignments: :assignment_spes, student: { assignments: :assigned_exercises })
                 .where('"assigned_exercises"."exercise_uuid" = "assignment_spes"."exercise_uuid"')
-                .where(assigned_exercises: { uuid: assigned_exercise_uuids })
+                .where(assigned_exercises: { uuid: anti_cheating_assigned_exercise_uuids })
                 .to_sql
             }
             UNION ALL
@@ -642,7 +647,9 @@ class Services::FetchCourseEvents::Service < Services::ApplicationService
               .where(
                 exercise_calculation: {
                   student: {
-                    assignments: { assigned_exercises: { uuid: assigned_exercise_uuids } }
+                    assignments: {
+                      assigned_exercises: { uuid: anti_cheating_assigned_exercise_uuids }
+                    }
                   }
                 }
               )
@@ -660,7 +667,9 @@ class Services::FetchCourseEvents::Service < Services::ApplicationService
               .where(
                 exercise_calculation: {
                   student: {
-                    assignments: { assigned_exercises: { uuid: assigned_exercise_uuids } }
+                    assignments: {
+                      assigned_exercises: { uuid: anti_cheating_assigned_exercise_uuids }
+                    }
                   }
                 }
               )
@@ -714,8 +723,9 @@ class Services::FetchCourseEvents::Service < Services::ApplicationService
           :student_pes, exercise_calculation: { student: { assignments: :assigned_exercises } }
         )
         .where('"assigned_exercises"."exercise_uuid" = "student_pes"."exercise_uuid"')
-        .where(assigned_exercises: { uuid: assigned_exercise_uuids })
-        .ordered_update_all(is_pending_for_student: true) unless assigned_exercise_uuids.empty?
+        .where(assigned_exercises: { uuid: anti_cheating_assigned_exercise_uuids })
+        .ordered_update_all(is_pending_for_student: true) \
+          unless anti_cheating_assigned_exercise_uuids.empty?
 
       # Get assignments that need PEs or SPEs and do not yet have an ExerciseCalculation
       default_calculation_assignments = Assignment.need_pes_or_spes.joins(

--- a/app/domain/services/prepare_exercise_calculations/service.rb
+++ b/app/domain/services/prepare_exercise_calculations/service.rb
@@ -53,8 +53,8 @@ class Services::PrepareExerciseCalculations::Service < Services::ApplicationServ
               ).arel.exists
             )
           )
-          .joins(:student)
           .need_pes_or_spes
+          .joins(:student)
           .lock('FOR NO KEY UPDATE OF "students" SKIP LOCKED')
           .limit(BATCH_SIZE)
           .pluck(st[:uuid], :ecosystem_uuid)
@@ -130,8 +130,8 @@ class Services::PrepareExerciseCalculations::Service < Services::ApplicationServ
     # We don't care about missing assignments here because we call this method every iteration
     # No order needed because of SKIP LOCKED
     assignment_uuids = Assignment
-      .joins(:student)
       .need_pes_or_spes
+      .joins(:student)
       .where(has_exercise_calculation: false)
       .where(
         ExerciseCalculation.where(

--- a/db/migrate/20200129215718_index_assigned_exercises_on_exercise_uuid.rb
+++ b/db/migrate/20200129215718_index_assigned_exercises_on_exercise_uuid.rb
@@ -1,0 +1,5 @@
+class IndexAssignedExercisesOnExerciseUuid < ActiveRecord::Migration[5.2]
+  def change
+    add_index :assigned_exercises, :exercise_uuid
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_01_24_225041) do
+ActiveRecord::Schema.define(version: 2020_01_29_215718) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -80,6 +80,7 @@ ActiveRecord::Schema.define(version: 2020_01_24_225041) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["assignment_uuid", "is_spe", "is_pe"], name: "index_assigned_exercises_on_a_uuid_and_is_spe_and_is_pe"
+    t.index ["exercise_uuid"], name: "index_assigned_exercises_on_exercise_uuid"
     t.index ["uuid"], name: "index_assigned_exercises_on_uuid", unique: true
   end
 

--- a/spec/domain/services/fetch_course_events/service_spec.rb
+++ b/spec/domain/services/fetch_course_events/service_spec.rb
@@ -509,8 +509,8 @@ RSpec.describe Services::FetchCourseEvents::Service, type: :service do
       let(:assigned_book_container_uuids)     do
         num_assigned_book_container_uuids.times.map { SecureRandom.uuid }
       end
-      let(:goal_num_tutor_assigned_spes)      { rand 5 }
-      let(:spes_are_assigned)                 { [true, false].sample }
+      let(:goal_num_tutor_assigned_spes)      { rand(5) + 1 }
+      let(:spes_are_assigned)                 { false }
       let(:goal_num_tutor_assigned_pes)       { rand 2 }
       let(:pes_are_assigned)                  { [true, false].sample }
       let(:num_assigned_exercises)            { 10 }

--- a/spec/domain/services/upload_assignment_exercises/service_spec.rb
+++ b/spec/domain/services/upload_assignment_exercises/service_spec.rb
@@ -90,13 +90,13 @@ RSpec.describe Services::UploadAssignmentExercises::Service, type: :service do
                          to_book_container_uuid: @reading_pool_3_old.book_container_uuid
       @reading_pool_4_old = FactoryBot.create(
         :exercise_pool,
-        exercises_count: 7,
+        exercises_count: 14,
         ecosystem_uuid: ecosystem_1.uuid,
         use_for_personalized_for_assignment_types: ['reading']
       )
       @reading_pool_4_new = FactoryBot.create(
         :exercise_pool,
-        exercises_count: 7,
+        exercises_count: 14,
         ecosystem_uuid: ecosystem_2.uuid,
         use_for_personalized_for_assignment_types: ['reading']
       )
@@ -318,9 +318,7 @@ RSpec.describe Services::UploadAssignmentExercises::Service, type: :service do
         is_deleted: false
       )
 
-      # 2 SPEs (1 random-ago), 1 PEs requested; PE is filled
-      # EO: 1-ago SPE filled from reading 1, random-ago SPE filled as PE
-      # RO: 1-ago SPE filled from reading 3, random-ago SPE filled as PE
+      # 2 SPEs (1 random-ago), 1 PEs requested; can be filled
       @reading_2 = FactoryBot.create(
         :assignment,
         course_uuid: course.uuid,
@@ -342,9 +340,7 @@ RSpec.describe Services::UploadAssignmentExercises::Service, type: :service do
         is_deleted: false
       )
 
-      # 3 SPEs (1 random-ago), 2 PEs requested; PEs are filled taking 2 out of 3 available exercises
-      # EO: 1-ago SPE filled from reading 2, 3-ago SPE filled as PE, random-ago SPE unfilled
-      # RO: Only 1-ago SPE filled as PE
+      # 3 SPEs (1 random-ago), 2 PEs requested; can be filled
       @reading_3 = FactoryBot.create(
         :assignment,
         course_uuid: course.uuid,
@@ -368,7 +364,6 @@ RSpec.describe Services::UploadAssignmentExercises::Service, type: :service do
 
       # These homeworks are taking all available exercises, so no PEs are possible
 
-      # Immediate feedback
       # 3 SPEs, 1 PE requested; PE cannot be filled
       # EO: No exercises available to fill anything
       # RO: Only 1-ago SPE can be filled from homework 2
@@ -393,11 +388,7 @@ RSpec.describe Services::UploadAssignmentExercises::Service, type: :service do
         is_deleted: false
       )
 
-      # Immediate feedback
-      # 2 SPEs, 1 PE requested; PE cannot be filled
-      # EO: Only 1-ago SPE can be filled from homework 1
-      # RO: No exercises available to fill anything
-      #     (1-ago SPE would be filled from homework 3 if homework 3 had immediate feedback)
+      # 2 SPEs, 1 PE requested; cannot be filled
       @homework_2 = FactoryBot.create(
         :assignment,
         course_uuid: course.uuid,
@@ -419,10 +410,7 @@ RSpec.describe Services::UploadAssignmentExercises::Service, type: :service do
         is_deleted: false
       )
 
-      # Feedback on due date
-      # 3 SPEs, 1 PE requested; PE cannot be filled
-      # EO: Only 1-ago SPE can be filled from homework 2
-      # RO: No exercises available to fill anything
+      # 3 SPEs, 1 PE requested; cannot be filled
       @homework_3 = FactoryBot.create(
         :assignment,
         course_uuid: course.uuid,
@@ -542,10 +530,10 @@ RSpec.describe Services::UploadAssignmentExercises::Service, type: :service do
     end
 
     let(:expected_num_spes) do
-      expected_assignment_spes.map { |calc| calc[:exercise_count] }.reduce(0, :+)
+      expected_assignment_spes.map { |calc| calc[:exercise_count] }.sum
     end
     let(:expected_num_pes) do
-      expected_assignment_pes.map { |calc| calc[:exercise_count] }.reduce(0, :+)
+      expected_assignment_pes.map { |calc| calc[:exercise_count] }.sum
     end
 
     before do
@@ -594,20 +582,18 @@ RSpec.describe Services::UploadAssignmentExercises::Service, type: :service do
             assignment_uuid: @reading_3.uuid,
             history_type: 'instructor_driven',
             exercise_pool: @reading_pool_3_new.exercise_uuids +
-                           @reading_pool_4_new.exercise_uuids +
-                           @reading_pool_5_new.exercise_uuids -
+                           @reading_pool_4_new.exercise_uuids -
                            @reading_3.assigned_exercise_uuids,
-            exercise_count: 2
+            exercise_count: 3
           },
           {
             algorithm_exercise_calculation: @algorithm_exercise_calculation_2,
             assignment_uuid: @reading_3.uuid,
             history_type: 'student_driven',
             exercise_pool: @reading_pool_3_new.exercise_uuids +
-                           @reading_pool_4_new.exercise_uuids +
-                           @reading_pool_5_new.exercise_uuids -
+                           @reading_pool_4_new.exercise_uuids -
                            @reading_3.assigned_exercise_uuids,
-            exercise_count: 2
+            exercise_count: 3
           },
           {
             algorithm_exercise_calculation: @algorithm_exercise_calculation_1,
@@ -627,33 +613,29 @@ RSpec.describe Services::UploadAssignmentExercises::Service, type: :service do
             algorithm_exercise_calculation: @algorithm_exercise_calculation_2,
             assignment_uuid: @homework_2.uuid,
             history_type: 'instructor_driven',
-            exercise_pool: @homework_pool_1_new.exercise_uuids +
-                           @homework_pool_2_new.exercise_uuids,
-            exercise_count: 1
+            exercise_pool: [],
+            exercise_count: 0
           },
           {
             algorithm_exercise_calculation: @algorithm_exercise_calculation_2,
             assignment_uuid: @homework_2.uuid,
             history_type: 'student_driven',
-            exercise_pool: @homework_pool_1_new.exercise_uuids +
-                           @homework_pool_2_new.exercise_uuids,
-            exercise_count: 1
+            exercise_pool: [],
+            exercise_count: 0
           },
           {
             algorithm_exercise_calculation: @algorithm_exercise_calculation_2,
             assignment_uuid: @homework_3.uuid,
             history_type: 'instructor_driven',
-            exercise_pool: @homework_pool_3_new.exercise_uuids +
-                           @homework_pool_4_new.exercise_uuids,
-            exercise_count: 1
+            exercise_pool: [],
+            exercise_count: 0
           },
           {
             algorithm_exercise_calculation: @algorithm_exercise_calculation_2,
             assignment_uuid: @homework_3.uuid,
             history_type: 'student_driven',
-            exercise_pool: @homework_pool_3_new.exercise_uuids +
-                           @homework_pool_4_new.exercise_uuids,
-            exercise_count: 1
+            exercise_pool: [],
+            exercise_count: 0
           }
         ]
       end
@@ -729,10 +711,9 @@ RSpec.describe Services::UploadAssignmentExercises::Service, type: :service do
             assignment_uuid: @reading_3.uuid,
             history_type: 'instructor_driven',
             exercise_pool: @reading_pool_3_new.exercise_uuids +
-                           @reading_pool_4_new.exercise_uuids +
-                           @reading_pool_5_new.exercise_uuids -
+                           @reading_pool_4_new.exercise_uuids -
                            @reading_3.assigned_exercise_uuids,
-            exercise_count: 2
+            exercise_count: 3
           },
           {
             algorithm_exercise_calculation: @algorithm_exercise_calculation_2,
@@ -741,7 +722,7 @@ RSpec.describe Services::UploadAssignmentExercises::Service, type: :service do
             exercise_pool: @reading_pool_4_new.exercise_uuids +
                            @reading_pool_5_new.exercise_uuids -
                            @reading_3.assigned_exercise_uuids,
-            exercise_count: 1
+            exercise_count: 3
           },
           {
             algorithm_exercise_calculation: @algorithm_exercise_calculation_1,
@@ -762,9 +743,8 @@ RSpec.describe Services::UploadAssignmentExercises::Service, type: :service do
             algorithm_exercise_calculation: @algorithm_exercise_calculation_2,
             assignment_uuid: @homework_2.uuid,
             history_type: 'instructor_driven',
-            exercise_pool: @homework_pool_1_new.exercise_uuids +
-                           @homework_pool_2_new.exercise_uuids,
-            exercise_count: 1
+            exercise_pool: [],
+            exercise_count: 0
           },
           {
             algorithm_exercise_calculation: @algorithm_exercise_calculation_2,
@@ -777,9 +757,8 @@ RSpec.describe Services::UploadAssignmentExercises::Service, type: :service do
             algorithm_exercise_calculation: @algorithm_exercise_calculation_2,
             assignment_uuid: @homework_3.uuid,
             history_type: 'instructor_driven',
-            exercise_pool: @homework_pool_3_new.exercise_uuids +
-                           @homework_pool_4_new.exercise_uuids,
-            exercise_count: 1
+            exercise_pool: [],
+            exercise_count: 0
           },
           {
             algorithm_exercise_calculation: @algorithm_exercise_calculation_2,


### PR DESCRIPTION
- Anti-cheating is now based on both due and feedback dates
- Skip anti-cheating (checking all other assignments) when receiving a task without due/feedback dates
- Anti-cheating only checks tasks that still need PEs or SPEs
- Mark SPEs for recalculation when they have already been used as PEs elsewhere

This should greatly speed up fetch_course_events