### PR TITLE
Reduce the course event batch size to 1

### DIFF
--- a/app/domain/services/fetch_course_events/service.rb
+++ b/app/domain/services/fetch_course_events/service.rb
@@ -1,7 +1,7 @@
 class Services::FetchCourseEvents::Service < Services::ApplicationService
   include Services::AssignmentExerciseRequests
 
-  BATCH_SIZE = 1000
+  BATCH_SIZE = 1
   GRACE_PERIOD = 1.month
 
   # create_course is already included in the metadata

--- a/spec/domain/services/fetch_course_events/service_spec.rb
+++ b/spec/domain/services/fetch_course_events/service_spec.rb
@@ -36,16 +36,23 @@ RSpec.describe Services::FetchCourseEvents::Service, type: :service do
     let(:course_events_response) do
       {
         request_uuid: SecureRandom.uuid,
-        course_uuid: course.uuid,
-        events: course_events,
+        events: [],
         is_gap: false,
         is_end: true
       }
     end
 
     before                       do
-      expect(OpenStax::Biglearn::Api).to receive(:fetch_course_events) do |requests|
-        { requests.first => course_events_response }
+      expect(OpenStax::Biglearn::Api).to receive(:fetch_course_events).at_least(:once) do |requests|
+        {}.tap do |response|
+          requests.each do |request|
+            response[request] = course_events_response.merge(
+              course_uuid: request[:course].uuid
+            )
+
+            response[request][:events] = course_events if request[:course].uuid == course.uuid
+          end
+        end
       end
     end
 


### PR DESCRIPTION
Because some course events take forever to process (probably creating new assignments for preview courses),  it is better to process 1 course at a time for now to prevent other courses from being locked for too long.

Temporary fix for until we add delayed_job or que or queue_classic.

Production had this fix added manually as it seemed necessary to keep it stable.