### PR TITLE
Made anti-cheating faster and renamed it to deduplication

### DIFF
--- a/app/domain/services/prepare_exercise_calculations/service.rb
+++ b/app/domain/services/prepare_exercise_calculations/service.rb
@@ -96,7 +96,7 @@ class Services::PrepareExerciseCalculations::Service < Services::ApplicationServ
               ON "exercise_calculations"."student_uuid" = "values"."student_uuid"::uuid
                 AND "exercise_calculations"."ecosystem_uuid" = "values"."ecosystem_uuid"::uuid
           JOIN_SQL
-        ).where(superseded_at: nil).ordered_update_all superseded_at: start_time
+        ).not_superseded.ordered_update_all superseded_at: start_time
 
         # Record the ExerciseCalculations
         ExerciseCalculation.import(

--- a/app/domain/services/update_student_history/service.rb
+++ b/app/domain/services/update_student_history/service.rb
@@ -136,7 +136,8 @@ class Services::UpdateStudentHistory::Service < Services::ApplicationService
     # concurrent Assignment and AlgorithmExerciseCalculation inserts
     exercise_calculation_uuids = ExerciseCalculation
       .joins(:assignments)
-      .where(assignments: { student_uuid: student_uuids }, superseded_at: nil)
+      .not_superseded
+      .where(assignments: { student_uuid: student_uuids })
       .ordered
       .lock('FOR NO KEY UPDATE OF "exercise_calculations"')
       .pluck(:uuid)

--- a/db/migrate/20200221231419_index_active_exercise_calculations_on_student_uuid_and_ecosystem_uuid.rb
+++ b/db/migrate/20200221231419_index_active_exercise_calculations_on_student_uuid_and_ecosystem_uuid.rb
@@ -1,0 +1,7 @@
+class IndexActiveExerciseCalculationsOnStudentUuidAndEcosystemUuid < ActiveRecord::Migration[5.2]
+  def change
+    add_index :exercise_calculations, [ :student_uuid, :ecosystem_uuid ],
+              where: '"superseded_at" IS NULL',
+              name: 'index_active_ex_calc_on_student_uuid_and_ecosystem_uuid'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_02_14_175452) do
+ActiveRecord::Schema.define(version: 2020_02_21_231419) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -263,6 +263,7 @@ ActiveRecord::Schema.define(version: 2020_02_14_175452) do
     t.datetime "superseded_at"
     t.index ["algorithm_names"], name: "index_exercise_calculations_on_algorithm_names", using: :gin
     t.index ["ecosystem_uuid"], name: "index_exercise_calculations_on_ecosystem_uuid"
+    t.index ["student_uuid", "ecosystem_uuid"], name: "index_active_ex_calc_on_student_uuid_and_ecosystem_uuid", where: "(superseded_at IS NULL)"
     t.index ["student_uuid", "ecosystem_uuid"], name: "index_exercise_calculations_on_student_uuid_and_ecosystem_uuid"
     t.index ["superseded_at"], name: "index_deletable_exercise_calculations_on_superseded_at", where: "(NOT is_used_in_assignments)"
     t.index ["uuid"], name: "index_exercise_calculations_on_uuid", unique: true


### PR DESCRIPTION
Turns out we do need the anti-cheating code for new assignments due to the way we calculate personalized exercises for them. Otherwise we may get a bunch of duplicates.

2 changes here that will make it faster:
1. Check only AssignedExercises that were modified in the request, not all of them.
2. Check only ExerciseCalculations that are not superseded (except the last query in the UNION ALL, that one wants ExerciseCalculations regardless of superseded state)