### PR TITLE
Fix NoMethodError when the AssignedExercise import returns no rows

### DIFF
--- a/app/domain/services/fetch_course_events/service.rb
+++ b/app/domain/services/fetch_course_events/service.rb
@@ -531,7 +531,7 @@ class Services::FetchCourseEvents::Service < Services::ApplicationService
       }, returning: [ :uuid ]
     )
     failures += result.failed_instances.size
-    imported_assigned_exercise_uuids = result.results
+    imported_assigned_exercise_uuids = result.results || []
 
     # NOTE: update happens when an answer is changed
     #       first_responded_at is not included here so it is never updated after set


### PR DESCRIPTION
Due to ON CONFLICT DO NOTHING

https://sentry.cnx.org/openstax/biglearn-scheduler/issues/82792/